### PR TITLE
Phase 1: Add expandable-blocks dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@directus/extensions-sdk": "^11.0.0",
     "@directus/stores": "^1.0.2",
+    "directus-extension-expandable-blocks": "^1.3.0",
     "lodash-es": "^4.17.21",
     "vue": "^3.4.0",
     "vuedraggable": "^4.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@directus/stores':
         specifier: ^1.0.2
         version: 1.0.3(pinia@2.3.1(typescript@5.9.2)(vue@3.5.20(typescript@5.9.2)))(vue@3.5.20(typescript@5.9.2))
+      directus-extension-expandable-blocks:
+        specifier: ^1.3.0
+        version: 1.3.0(vue@3.5.20(typescript@5.9.2))
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1628,6 +1631,10 @@ packages:
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  directus-extension-expandable-blocks@1.3.0:
+    resolution: {integrity: sha512-VDMHDpZLXslJBZdV6llh1SweGEeSf5gKbWqEIQwzsbbX37FTeGG0xvhWDjT/yyOclUHJe1/94mjA0m5a4CbQaQ==}
+    engines: {node: '>=16'}
 
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -4835,6 +4842,13 @@ snapshots:
     optional: true
 
   diff-sequences@29.6.3: {}
+
+  directus-extension-expandable-blocks@1.3.0(vue@3.5.20(typescript@5.9.2)):
+    dependencies:
+      lodash-es: 4.17.21
+      vuedraggable: 4.1.0(vue@3.5.20(typescript@5.9.2))
+    transitivePeerDependencies:
+      - vue
 
   doctrine@3.0.0:
     dependencies:

--- a/src/shared/README.md
+++ b/src/shared/README.md
@@ -1,0 +1,81 @@
+# Shared Components from expandable-blocks
+
+This directory documents the available shared components and composables from the `directus-extension-expandable-blocks` package.
+
+## Available Imports
+
+### Composables
+
+```typescript
+import { useItemSelector } from 'directus-extension-expandable-blocks/shared';
+```
+
+The main composable that provides ItemSelector functionality:
+- Opens ItemSelector dialog
+- Manages search and filtering
+- Handles pagination
+- Provides multi-language support
+- Manages permissions
+
+### Components
+
+```typescript
+import { ItemSelectorDrawer } from 'directus-extension-expandable-blocks/shared';
+```
+
+The main drawer component for item selection:
+- Full-featured item browser
+- Search and filter capabilities
+- Link and Duplicate modes
+- Permission-aware UI
+
+### Type Definitions
+
+```typescript
+import type { 
+  ItemSelectorConfig,
+  ItemSelectorReturn,
+  TranslationInfo,
+  FieldWithTranslation 
+} from 'directus-extension-expandable-blocks/shared';
+```
+
+TypeScript type definitions for:
+- `ItemSelectorConfig` - Configuration options
+- `ItemSelectorReturn` - Return type of useItemSelector
+- `TranslationInfo` - Translation metadata
+- `FieldWithTranslation` - Field with translation support
+
+## Usage Example
+
+```typescript
+import { useItemSelector, ItemSelectorDrawer } from 'directus-extension-expandable-blocks/shared';
+import type { ItemSelectorConfig } from 'directus-extension-expandable-blocks/shared';
+
+// In your component setup
+const itemSelector = useItemSelector(api, allowedCollections, {
+  loggerPrefix: '[LayoutBlocks]',
+  allowLink: true,
+  allowDuplicate: true,
+  defaultItemsPerPage: 50
+});
+
+// Open the selector
+itemSelector.open('collection_name');
+
+// Handle selection
+const handleItemSelection = (items: any[]) => {
+  // Process selected items
+  itemSelector.close();
+};
+```
+
+## Version
+
+Currently using: `directus-extension-expandable-blocks@^1.3.0`
+
+## Documentation
+
+For detailed documentation, see:
+- [SHARED_COMPONENTS.md](../../expandable-blocks/SHARED_COMPONENTS.md)
+- [GitHub Repository](https://github.com/smartlabsAT/directus-expandable-blocks)


### PR DESCRIPTION
## 📦 Phase 1: Dependency Setup & Shared Components Import

Part of #8 - ItemSelector Integration  
Closes #9

## ✅ What was done

### 1. Package Configuration
- [x] Added `directus-extension-expandable-blocks` (^1.3.0) to dependencies
- [x] Ran `pnpm install` to install the package
- [x] Verified the package exports are accessible

### 2. Build System Verification
- [x] `npm run build` - ✅ Successful
- [x] `npm run type-check` - ✅ Successful
- [x] All imports work correctly

### 3. Documentation
- [x] Created `/src/shared/README.md` with import examples
- [x] Documented available components and composables
- [x] Added usage examples

## 📝 Changes

- **package.json**: Added expandable-blocks dependency
- **pnpm-lock.yaml**: Updated with new dependency
- **src/shared/README.md**: Documentation for available imports

## 🔍 Verification

```typescript
// These imports now work:
import { useItemSelector, ItemSelectorDrawer } from 'directus-extension-expandable-blocks/shared';
import type { ItemSelectorConfig } from 'directus-extension-expandable-blocks/shared';
```

## ✅ Testing

- Build process: ✅ Passed
- TypeScript checking: ✅ Passed
- Import verification: ✅ Passed

## 📋 Next Steps

Phase 2: BlockCreator UI Extension (#10)