### PR TITLE
fix: default a fallback id for layout areas configured without one

### DIFF
--- a/src/interface.vue
+++ b/src/interface.vue
@@ -254,6 +254,7 @@ import { useBlocks } from './composables/useBlocks';
 import { usePermissions } from './composables/usePermissions';
 import { useBlockPermissions } from './composables/useBlockPermissions';
 import { DEFAULT_OPTIONS, DEFAULT_AREA_CONFIG } from './utils/constants';
+import { normalizeAreaIds } from './utils/helpers';
 import { CUSTOM_AREAS, USE_CUSTOM_AREAS } from './config/areas';
 import type { 
   LayoutBlocksOptions, 
@@ -492,7 +493,13 @@ const computedAreas = computed<AreaConfig[]>(() => {
   else {
     areas = [...DEFAULT_AREA_CONFIG];
   }
-  
+
+  // Harden against areas configured without an `id`. Without this, such areas
+  // render with `id: undefined` and their blocks (keyed by area) silently
+  // disappear. Default a missing id from the label, the configured defaultArea,
+  // or the index. Areas that already have an id are left unchanged.
+  areas = normalizeAreaIds(areas, options.value.defaultArea || 'main');
+
   // Only add orphaned area if there are orphaned blocks
   const hasOrphanedBlocks = blocks.value.some(b => b.area === 'orphaned');
   const hasOrphanedArea = areas.some(a => a.id === 'orphaned');

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -42,3 +42,43 @@ export function formatCollectionName(collection: string): string {
     .replace(/_/g, ' ')
     .replace(/\b\w/g, l => l.toUpperCase());
 }
+
+/**
+ * Ensure every layout area has a stable, unique `id`.
+ *
+ * The interface filters blocks per area by `area.id`. An area configured without
+ * an `id` (e.g. only a width) renders with `id: undefined`, so stored blocks —
+ * which always carry an area key (defaulting to `defaultAreaId` on read) — never
+ * match and silently disappear from the UI. This derives a fallback id from the
+ * label, the configured default area, or the index, and guarantees uniqueness.
+ * Areas that already have an `id` are returned unchanged (backward compatible).
+ */
+export function normalizeAreaIds<T extends { id?: string; label?: string }>(
+  areas: T[],
+  defaultAreaId = 'main'
+): T[] {
+  const usedIds = new Set<string>();
+
+  return areas.map((area, index) => {
+    let id = (area.id ?? '').trim();
+
+    if (!id) {
+      const fromLabel = (area.label ?? '')
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+      id = fromLabel || (index === 0 ? defaultAreaId : `area-${index + 1}`);
+    }
+
+    // Guarantee uniqueness when labels collide or ids repeat.
+    let uniqueId = id;
+    let suffix = 2;
+    while (usedIds.has(uniqueId)) {
+      uniqueId = `${id}-${suffix++}`;
+    }
+    usedIds.add(uniqueId);
+
+    return area.id === uniqueId ? area : { ...area, id: uniqueId };
+  });
+}

--- a/test/unit/helpers.test.ts
+++ b/test/unit/helpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeAreaIds } from '../../src/utils/helpers';
+
+describe('normalizeAreaIds', () => {
+  it('leaves areas that already have an id unchanged', () => {
+    const areas = [{ id: 'main', label: 'Main' }, { id: 'footer', label: 'Footer' }];
+    const result = normalizeAreaIds(areas);
+    expect(result.map(a => a.id)).toEqual(['main', 'footer']);
+    // Identity is preserved when nothing changes (avoids needless re-renders).
+    expect(result[0]).toBe(areas[0]);
+  });
+
+  it('defaults a single area without an id to the default area id', () => {
+    const result = normalizeAreaIds([{ width: 100 } as any]);
+    expect(result[0].id).toBe('main');
+  });
+
+  it('respects a custom default area id', () => {
+    const result = normalizeAreaIds([{ width: 100 } as any], 'content');
+    expect(result[0].id).toBe('content');
+  });
+
+  it('derives an id from the label when present', () => {
+    const result = normalizeAreaIds([{ label: 'Right Sidebar' } as any]);
+    expect(result[0].id).toBe('right-sidebar');
+  });
+
+  it('falls back to an indexed id for additional unlabeled areas', () => {
+    const result = normalizeAreaIds([{ width: 100 } as any, { width: 50 } as any]);
+    expect(result.map(a => a.id)).toEqual(['main', 'area-2']);
+  });
+
+  it('guarantees unique ids when labels collide', () => {
+    const result = normalizeAreaIds([{ label: 'Main' } as any, { label: 'Main' } as any]);
+    expect(result.map(a => a.id)).toEqual(['main', 'main-2']);
+  });
+});


### PR DESCRIPTION
## Summary
Areas configured without an `id` (e.g. `areas: [{ width: 100 }]`) rendered with `id: undefined`. The interface filters blocks per area by `area.id`, so stored blocks — which carry an area key (defaulting to `main` on read) — never matched and silently disappeared from the UI after a reload, even though the junction data was intact.

`computedAreas` now runs the configured areas through a new `normalizeAreaIds` helper that guarantees every area has a stable, unique id, derived from the label, the configured `defaultArea`, or the index. Areas that already have an id are returned unchanged (backward compatible).

## Changes
- `src/utils/helpers.ts` — new `normalizeAreaIds` helper
- `src/interface.vue` — apply it in `computedAreas`
- `test/unit/helpers.test.ts` — unit tests for the helper

## Test plan
- `npm run test` — 6/6 unit tests pass
- `npm run type-check` — passes
- Reproduced the bug on a throwaway collection (block vanished after reload), then confirmed it renders once areas carry an id.

## Notes for existing fields
No data migration needed. Existing affected fields can be corrected purely via config by setting the area `id` (e.g. `"main"`); the block data is intact in the junction.

Closes #36
