### PR TITLE
fix: stop block click from selecting the whole area

### DIFF
--- a/src/components/BlockItem.vue
+++ b/src/components/BlockItem.vue
@@ -8,7 +8,7 @@
     }"
     :data-block-id="block.id"
     :draggable="draggable"
-    @click="handleClick"
+    @click.stop="handleClick"
     @dblclick="handleDoubleClick"
   >
     <!-- Block Icon/Type Indicator -->


### PR DESCRIPTION
## Summary
In an area with more than one block, clicking a single block visually selected the **entire area**, so every block in that area appeared selected.

The block's click handler (`@click="handleClick"` in `BlockItem.vue`) toggled the block's own `isSelected` but did not stop propagation. The click bubbled up to the area element, which has `@click="selectArea(area.id)"` in `GridView.vue`, so the area also got the `.grid-area.selected` full-area highlight.

Adding `.stop` to the block click makes a click select only that block; the area is still selectable via its empty space.

## Changes
- `src/components/BlockItem.vue` — `@click="handleClick"` → `@click.stop="handleClick"`

## Test plan
- `npm run type-check` — passes
- Built the extension and verified in the browser on an item with two blocks in one area:
  - **Before:** clicking one block highlighted the whole area (both blocks).
  - **After:** only the clicked block is highlighted (`.block-item.selected` on the clicked block only, no `.grid-area.selected`).

Closes #38
