### PR TITLE
fix: enable dragging blocks between areas (3 root causes)

### DIFF
--- a/src/components/BlockItem.vue
+++ b/src/components/BlockItem.vue
@@ -8,6 +8,7 @@
     }"
     :data-block-id="block.id"
     :draggable="draggable"
+    v-bind="$attrs"
     @click="handleClick"
     @dblclick="handleDoubleClick"
   >
@@ -132,6 +133,12 @@ import type { BlockItem, AreaConfig, UserPermissions } from '../types';
 import { getBlockIcon, getBlockTitle, getBlockSubtitle, getCollectionLabel } from '../utils/blockHelpers';
 import StatusSelector from './StatusSelector.vue';
 import DeleteConfirmationDialog from './DeleteConfirmationDialog.vue';
+
+// This component has multiple root nodes (the block element + the delete dialog),
+// so Vue cannot auto-inherit fallthrough listeners. Without this, the parent's
+// @dragstart / @dragend listeners were silently dropped and drag-and-drop never
+// started. Disable auto-inherit and bind $attrs explicitly on the draggable root.
+defineOptions({ inheritAttrs: false });
 
 // Props
 interface Props {

--- a/src/composables/useBlockPermissions.ts
+++ b/src/composables/useBlockPermissions.ts
@@ -224,18 +224,12 @@ export function useBlockPermissions(
     /**
      * Validate moving a block between areas
      */
-    validateMoveBlock: (fromArea: string, toArea: string, collection: string): ValidationResult => {
-      // Check permissions
-      if (!permissions.canUpdateItems(collection)) {
-        return {
-          valid: false,
-          error: 'You do not have permission to move blocks'
-        };
-      }
-
-      // Check if target area allows this collection type
-      // This would require area-specific configuration
-      
+    validateMoveBlock: (_fromArea: string, _toArea: string, _collection: string): ValidationResult => {
+      // Moving a block only updates the junction row's area/sort. Authorization
+      // is enforced server-side by the API on that update, so no client-side
+      // permission gate is needed here. The previous canUpdateItems() check was
+      // unreliable under the Directus 11 policy-based permission model and
+      // wrongly blocked legitimate users (including admins).
       return { valid: true };
     },
 

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -1170,7 +1170,6 @@ async function handleMoveBlock(data: {
   try {
     await moveBlock(
       data.blockId,
-      data.fromArea,
       data.toArea,
       data.toIndex
     );


### PR DESCRIPTION
## Summary
Dragging a block from one area to another did nothing. It was a cascade of three independent bugs — all three are needed for drag-to-move to work.

1. **Drag never started.** `BlockItem.vue` has multiple root nodes (block + delete dialog), so Vue dropped the parent's fallthrough `@dragstart` / `@dragend` listeners and `draggedBlock` was never set. → `inheritAttrs: false` + `v-bind="$attrs"` on the draggable root.
2. **Wrong move target.** `handleMoveBlock` passed `moveBlock(blockId, fromArea, toArea, toIndex)` but the signature is `(blockId, targetArea, targetIndex)`, so a block was written back to its source area. → call `moveBlock(blockId, toArea, toIndex)`.
3. **Move rejected by a broken client permission check.** `validateMoveBlock` → `canUpdateItems` → `hasPermission` is incompatible with the Directus 11 policy-based permission model and returned false even for admins ("Cannot Move Block"). → drop the redundant client-side gate; the API authorizes the junction update server-side.

## Changes
- `src/components/BlockItem.vue` — attach drag listeners (`inheritAttrs: false` + `$attrs`)
- `src/interface.vue` — fix `handleMoveBlock` → `moveBlock` arguments
- `src/composables/useBlockPermissions.ts` — remove the unreliable `validateMoveBlock` permission gate

## Test plan
- `npm run type-check` — passes
- Built the extension and tested on a multi-area layout: a block dragged from Header to Left Sidebar updates the junction `area` and renders in the target area after reload; no "Cannot Move Block" error.

Closes #40
