### PR TITLE
fix: use integer sort values when reordering blocks

### DIFF
--- a/src/composables/useBlocks.ts
+++ b/src/composables/useBlocks.ts
@@ -446,32 +446,26 @@ export function useBlocks(
       throw new Error('Block not found');
     }
 
-    // Get blocks in target area
-    const targetBlocks = getBlocksForArea(targetArea);
-    
-    // Calculate new sort value
-    let newSort: number;
-    if (targetIndex !== undefined && targetIndex >= 0) {
-      if (targetIndex === 0) {
-        newSort = targetBlocks[0]?.sort - 1 || 0;
-      } else if (targetIndex >= targetBlocks.length) {
-        newSort = (targetBlocks[targetBlocks.length - 1]?.sort || 0) + 1;
-      } else {
-        const prevSort = targetBlocks[targetIndex - 1].sort;
-        const nextSort = targetBlocks[targetIndex].sort;
-        newSort = (prevSort + nextSort) / 2;
-      }
-    } else {
-      newSort = targetBlocks.length > 0
-        ? Math.max(...targetBlocks.map(b => b.sort)) + 1
-        : 0;
-    }
+    // Build the target area's order without the moved block, then insert it at
+    // the drop index. We renumber the whole area with sequential integer sort
+    // values (via reorderBlocks) instead of computing fractional midpoints,
+    // which the integer `sort` column rejects (e.g. a midpoint like -4.5 caused
+    // a 500 on the junction update).
+    const orderedIds = getBlocksForArea(targetArea)
+      .filter(b => b.id !== blockId)
+      .map(b => b.id);
 
-    // Update the block
-    await updateBlock(blockId, {
-      area: targetArea,
-      sort: newSort
-    });
+    const insertAt = targetIndex !== undefined && targetIndex >= 0
+      ? Math.min(targetIndex, orderedIds.length)
+      : orderedIds.length;
+    orderedIds.splice(insertAt, 0, blockId);
+
+    // Apply the area change first, then renumber the target area with clean
+    // integer sort values.
+    if (block.area !== targetArea) {
+      await updateBlock(blockId, { area: targetArea });
+    }
+    await reorderBlocks(targetArea, orderedIds);
   }
 
   return {


### PR DESCRIPTION
## Summary
Dropping a block **between** two existing blocks failed with a 500:

```
invalid input syntax for type integer: "-4.5"
```

`moveBlock` computed the new sort as the midpoint of the neighbours (`(prevSort + nextSort) / 2`), which is fractional, but the junction `sort` column is an integer. The index-0 branch (`targetBlocks[0]?.sort - 1`) also drifted sorts negative over repeated reorders.

The fix inserts the moved block at the drop index and renumbers the whole target area with sequential integer sort values via the existing `reorderBlocks()` helper — no fractional values, no negative drift.

## Changes
- `src/composables/useBlocks.ts` — `moveBlock` renumbers with integer sorts

## Test plan
- `npm run type-check` — passes
- Built and tested on a multi-area layout: dropping a block between two others in an area now succeeds; the target area is renumbered `0, 1, 2, …` (verified in the junction table and in the rendered order after reload); no 500.

Closes #42
