### PR TITLE
fix: drag drop-hint no longer shifts blocks (grid + list view)

### DIFF
--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -572,6 +572,7 @@ function handleAddBlock(areaId: string) {
 }
 
 .area-header {
+  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -691,14 +692,20 @@ function handleAddBlock(areaId: string) {
 </style>
 
 <style lang="scss">
-// Global styles for drag state
+// Global styles for drag state.
+// The drop hint is drawn as an absolutely-positioned overlay rather than a
+// border, so it never changes the header box height. A border would reflow the
+// content below it, and since drag-over toggles continuously while the pointer
+// moves, that made the blocks jump by the border width.
 body.dragging-block {
-  .grid-area {
-    &:not(.drag-over) {
-      .area-header {
-        border-bottom-style: dashed;
-      }
-    }
+  .grid-area:not(.drag-over) .area-header::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-bottom: 2px dashed var(--primary);
+    pointer-events: none;
   }
 }
 </style>

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -1028,9 +1028,13 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
 body.dragging-block {
   .area-tab {
     transition: all 0.2s ease;
-    
+
+    // Use an outline (does not affect layout) instead of changing the border
+    // style. A border change revealed a hidden border width and grew the tab,
+    // reflowing the content and making the blocks jump while dragging.
     &:not(.active) {
-      border-style: dashed;
+      outline: 2px dashed var(--primary);
+      outline-offset: -2px;
     }
   }
   


### PR DESCRIPTION
## Summary
While dragging, the drop hint changed an element's box size, which reflowed the content and made the blocks jump:
- **Grid view:** the area-header drop hint was a `border-bottom` (header height 52px → 55px → blocks jump ~3px).
- **List view:** the area tabs changed `border-style` to dashed, which grew the tab strip (~6px) and pushed the blocks down.

Both hints are now drawn without affecting layout — the grid hint as an absolutely-positioned `::after` overlay, the list hint as an `outline` — so the dashed indicators still show but nothing shifts.

## Changes
- `src/components/GridView.vue` — `.area-header { position: relative }` + drop hint as `::after` overlay
- `src/components/ListView.vue` — tab drag hint via `outline` instead of `border-style`

## Test plan
- `npm run type-check` — passes
- Built and measured in the browser for both views: with the drag state active the area header/tab height is unchanged and the first block's top position does not move (was +3px grid / +6px list before); the dashed hint still renders.

Closes #44
