### PR TITLE
feat: Directus global Save integration for layout blocks

### DIFF
--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -104,11 +104,12 @@
 import { logger } from '../utils/logger';
 import { ref, computed } from 'vue';
 import AddBlockDropdown from './AddBlockDropdown.vue';
-import type { 
-  BlockItem, 
-  AreaConfig, 
+import type {
+  BlockItem,
+  BlockId,
+  AreaConfig,
   LayoutBlocksOptions,
-  UserPermissions 
+  UserPermissions
 } from '../types';
 import BlockItemComponent from './BlockItem.vue';
 
@@ -129,16 +130,16 @@ const props = defineProps<Props>();
 const emit = defineEmits<{
   'update:selectedArea': [area: string | null];
   'move-block': [data: {
-    blockId: number;
+    blockId: BlockId;
     fromArea: string;
     toArea: string;
     toIndex: number;
   }];
-  'remove-block': [blockId: number];
-  'unlink-block': [blockId: number];
-  'delete-block': [blockId: number, deleteContent: boolean];
-  'update-block': [data: { blockId: number }];
-  'duplicate-block': [blockId: number];
+  'remove-block': [blockId: BlockId];
+  'unlink-block': [blockId: BlockId];
+  'delete-block': [blockId: BlockId, deleteContent: boolean];
+  'update-block': [data: { blockId: BlockId }];
+  'duplicate-block': [blockId: BlockId];
   'add-block': [area?: string];
   'create-quick': [data: { area: string; collection: string }];
   'open-selector': [data: { area: string; collection: string }];
@@ -422,8 +423,10 @@ function handleDrop(event: DragEvent, targetArea: AreaConfig) {
   let dropIndex = getAreaBlocks(targetArea.id).length;
   
   if (blockElement) {
-    const targetBlockId = parseInt(blockElement.getAttribute('data-block-id') || '0');
-    const targetBlock = props.blocks.find(b => b.id === targetBlockId);
+    // Compare as strings: temporary (unsaved) blocks carry string ids, so
+    // parseInt would yield NaN and break drop-targeting (see fix #40/#42).
+    const targetBlockId = blockElement.getAttribute('data-block-id') || '';
+    const targetBlock = props.blocks.find(b => String(b.id) === targetBlockId);
     if (targetBlock) {
       dropIndex = getAreaBlocks(targetArea.id).indexOf(targetBlock);
     }

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -250,6 +250,7 @@ import { ref, computed, onMounted, watch } from 'vue';
 import AddBlockDropdown from './AddBlockDropdown.vue';
 import type {
   BlockItem,
+  BlockId,
   AreaConfig,
   LayoutBlocksOptions,
   UserPermissions
@@ -272,14 +273,14 @@ const props = defineProps<Props>();
 const emit = defineEmits<{
   'update:selectedArea': [area: string | null];
   'move-block': [data: {
-    blockId: number;
+    blockId: BlockId;
     fromArea: string;
     toArea: string;
     toIndex: number;
   }];
-  'remove-block': [blockId: number];
-  'duplicate-block': [blockId: number];
-  'update-block': [data: { blockId: number; updates?: any }];
+  'remove-block': [blockId: BlockId];
+  'duplicate-block': [blockId: BlockId];
+  'update-block': [data: { blockId: BlockId; updates?: any }];
   'add-block': [area?: string];
   'create-quick': [data: { area: string; collection: string }];
   'open-selector': [data: { area: string; collection: string }];
@@ -622,7 +623,9 @@ function handleAreaDrop(event: DragEvent, targetAreaId: string) {
     return;
   }
   
-  const blockId = parseInt(event.dataTransfer!.getData('block-id'));
+  // Keep the id as a string: temporary (unsaved) blocks have string ids and
+  // parseInt would yield NaN, breaking the move (see fix #40/#42).
+  const blockId = event.dataTransfer!.getData('block-id');
   const sourceArea = draggedBlock.value.area;
   
   // Don't do anything if dropping on same area

--- a/src/composables/useBlocks.ts
+++ b/src/composables/useBlocks.ts
@@ -1,13 +1,22 @@
 import { logger } from '../utils/logger';
-import { ref, computed, unref, type Ref, type ComputedRef } from 'vue';
+import { ref, computed, unref, nextTick, type Ref, type ComputedRef } from 'vue';
+import { cloneDeep, isEqual } from 'lodash-es';
 import { useApi, useStores } from '@directus/extensions-sdk';
 import { M2AHelper } from '../utils/m2a-helper';
-import type { 
-  BlockItem, 
-  JunctionInfo, 
+import { generateTempId, isTempId, isExistingLink } from '../utils/helpers';
+import type {
+  BlockItem,
+  BlockId,
+  JunctionInfo,
   LayoutBlocksOptions,
   M2AFieldInfo
 } from '../types';
+
+/**
+ * Metadata fields stripped from an item before it is duplicated as a new block.
+ */
+const METADATA_FIELDS = ['id', 'user_created', 'user_updated', 'date_created', 'date_updated'];
+const TITLE_FIELDS = ['title', 'name', 'headline', 'label', 'heading'];
 
 export function useBlocks(
   collection: string,
@@ -21,16 +30,46 @@ export function useBlocks(
   const blocks = ref<BlockItem[]>([]);
   const loading = ref(false);
   const error = ref<Error | null>(null);
-  
-  // Initialize M2AHelper
+
+  // Initialize M2AHelper (used only for READS — global Save handles all writes)
   const m2aHelper = new M2AHelper(api, stores);
 
   // Get configured field names
   const areaField = computed(() => unref(options).areaField || 'area');
   const sortField = computed(() => unref(options).sortField || 'sort');
 
+  // --- State-based save tracking (global Save integration, issue #29) ---------
+  // Existing blocks explicitly marked dirty (content/area/sort changed). New
+  // blocks (temporary ids) are always dirty by nature. `isInternalUpdate` guards
+  // the interface's value/blocks watchers against feedback loops during our own
+  // emit and during loadBlocks().
+  const dirtyIds = ref<Set<BlockId>>(new Set());
+  const isInternalUpdate = ref(false);
+
+  function markBlockDirty(id: BlockId, dirty = true): void {
+    if (dirty) dirtyIds.value.add(id);
+    else dirtyIds.value.delete(id);
+  }
+
   /**
-   * Load all blocks for the current item using M2AHelper
+   * Snapshot the freshly-loaded state as the clean baseline. Called after every
+   * load so the global Save button only activates on subsequent user changes.
+   */
+  function resetTracking(): void {
+    dirtyIds.value.clear();
+  }
+
+  /**
+   * Next integer sort value for an area (per-area sequential integers — keeps the
+   * junction `sort` column integral, see fix #42).
+   */
+  function nextSortFor(area: string): number {
+    const areaBlocks = blocks.value.filter(b => b.area === area);
+    return areaBlocks.length > 0 ? Math.max(...areaBlocks.map(b => b.sort)) + 1 : 0;
+  }
+
+  /**
+   * Load all blocks for the current item using M2AHelper (read-only).
    */
   async function loadBlocks(): Promise<void> {
     if (!junctionInfo.value) {
@@ -42,7 +81,7 @@ export function useBlocks(
     const pk = unref(primaryKey);
     if (!pk || pk === '+' || pk === 'new') {
       logger.log('New item detected, skipping block load');
-      blocks.value = [];
+      applyLoaded([]);
       return;
     }
 
@@ -50,7 +89,6 @@ export function useBlocks(
     error.value = null;
 
     try {
-      // Create M2AFieldInfo from junction info
       const m2aFieldInfo: M2AFieldInfo = {
         field,
         collection,
@@ -64,31 +102,23 @@ export function useBlocks(
 
       logger.debug('Loading blocks with M2AHelper', { parentId: pk });
 
-      // Load blocks using M2AHelper
-      const loadedData = await m2aHelper.loadM2AData(
-        pk,
-        m2aFieldInfo,
-        0,
-        3
-      );
+      const loadedData = await m2aHelper.loadM2AData(pk, m2aFieldInfo, 0, 3);
 
-      // Transform loaded data to BlockItem format
-      blocks.value = loadedData.map((record: any) => ({
+      applyLoaded(loadedData.map((record: any) => ({
         id: record.id,
         area: record[areaField.value] || 'main',
         sort: record[sortField.value] || 0,
         collection: record.collection,
         item: record.item,
         _raw: record
-      }));
+      })));
 
       logger.debug(`Loaded ${blocks.value.length} blocks`);
 
     } catch (err: any) {
       error.value = err;
       logger.error('Failed to load blocks:', err);
-      
-      // Check if it's a permission error
+
       if (err.response?.status === 403) {
         logger.warn('Permission denied when loading blocks. User may not have access to junction collection.');
       }
@@ -98,7 +128,42 @@ export function useBlocks(
   }
 
   /**
-   * Get blocks for a specific area
+   * Apply freshly-loaded data to the blocks array as a programmatic (non-user)
+   * change. Wrapped in `isInternalUpdate` so the interface's emit/value watchers
+   * do not treat the reload as a user edit, and the dirty baseline is reset so
+   * the next user change re-activates Save.
+   *
+   * Reconciles IN PLACE: blocks whose id and content are unchanged keep their
+   * object identity, so Vue's keyed list does not re-render them — this prevents
+   * the post-save (Save & Stay) "flash" where the whole list blinked. Only
+   * genuinely changed blocks (e.g. reverted on Discard) and added/removed ones
+   * re-render.
+   */
+  function applyLoaded(next: BlockItem[]): void {
+    isInternalUpdate.value = true;
+
+    const currentById = new Map(blocks.value.map(b => [String(b.id), b]));
+    blocks.value = next.map((fresh) => {
+      const existing = currentById.get(String(fresh.id));
+      if (!existing) return fresh; // new or id-resolved block → fresh object
+      // Mutate in place only where something actually changed, preserving the
+      // object reference for untouched blocks.
+      if (existing.area !== fresh.area) existing.area = fresh.area;
+      if (existing.sort !== fresh.sort) existing.sort = fresh.sort;
+      if (existing.collection !== fresh.collection) existing.collection = fresh.collection;
+      if (!isEqual(existing.item, fresh.item)) existing.item = fresh.item;
+      existing._raw = fresh._raw;
+      return existing;
+    });
+
+    resetTracking();
+    nextTick(() => {
+      isInternalUpdate.value = false;
+    });
+  }
+
+  /**
+   * Get blocks for a specific area (sorted).
    */
   function getBlocksForArea(area: string): BlockItem[] {
     return blocks.value
@@ -107,350 +172,170 @@ export function useBlocks(
   }
 
   /**
-   * Add a new block (creates new item and links it)
+   * Add a new block (creates a new inline item, persisted on global Save).
    */
   async function addBlock(
     area: string,
     targetCollection: string,
     itemData: any
   ): Promise<void> {
-    if (!junctionInfo.value) {
-      throw new Error('Junction info not available');
-    }
-
-    const pk = unref(primaryKey);
-    if (!pk || pk === '+' || pk === 'new') {
-      throw new Error('Cannot add blocks to unsaved item');
-    }
-
-    try {
-      logger.debug('Creating new block', { area, targetCollection });
-
-      // Create the item in the target collection first
-      const itemResponse = await api.post(`/items/${targetCollection}`, itemData);
-      const newItemId = itemResponse.data.data.id;
-      logger.debug('Created new item', { id: newItemId });
-
-      // Link the item
-      await linkExistingItem(area, targetCollection, newItemId);
-
-    } catch (err: any) {
-      logger.error('Failed to add block:', err);
-      throw err;
-    }
+    const newBlock: BlockItem = {
+      id: generateTempId('new'),
+      area,
+      sort: nextSortFor(area),
+      collection: targetCollection,
+      item: { ...itemData }
+    };
+    blocks.value.push(newBlock);
+    logger.debug('New block staged (pending save)', { id: newBlock.id, area });
   }
 
   /**
-   * Link an existing item to the current record
+   * Link an existing item to the current record (persisted on global Save).
+   * The item content is fetched read-only for display; only the bare PK is
+   * emitted on save so the source item is never mutated.
    */
   async function linkExistingItem(
     area: string,
     targetCollection: string,
     itemId: string | number
   ): Promise<void> {
-    if (!junctionInfo.value) {
-      throw new Error('Junction info not available');
-    }
-
-    const pk = unref(primaryKey);
-    if (!pk || pk === '+' || pk === 'new') {
-      throw new Error('Cannot link items to unsaved record');
-    }
-
     try {
-      logger.debug('Linking existing item', {
-        area,
-        targetCollection,
-        itemId
-      });
-
-      // Get the next sort value for the area
-      const areaBlocks = getBlocksForArea(area);
-      const nextSort = areaBlocks.length > 0 
-        ? Math.max(...areaBlocks.map(b => b.sort)) + 1 
-        : 0;
-
-      // Create the junction record
-      const junctionData: any = {
-        [junctionInfo.value.foreignKeyField]: pk,
-        [junctionInfo.value.itemField]: itemId,
-        [junctionInfo.value.collectionField]: targetCollection
-      };
-
-      // Add area and sort fields if they exist
-      if (junctionInfo.value.hasAreaField) {
-        junctionData[areaField.value] = area;
-      }
-      if (junctionInfo.value.hasSortField) {
-        junctionData[sortField.value] = nextSort;
-      }
-
-      logger.debug('Creating junction record', junctionData);
-
-      const junctionResponse = await api.post(
-        `/items/${junctionInfo.value.collection}`,
-        junctionData
-      );
-
-      logger.debug('Junction record created', { id: junctionResponse.data.data.id });
-
-      // Load the full item data for display
+      // Read-only fetch of the item content for display.
       const itemResponse = await api.get(`/items/${targetCollection}/${itemId}`);
-      
-      // Add to local state
+
       const newBlock: BlockItem = {
-        id: junctionResponse.data.data.id,
+        id: generateTempId('existing'),
         area,
-        sort: nextSort,
+        sort: nextSortFor(area),
         collection: targetCollection,
         item: itemResponse.data.data
       };
-
       blocks.value.push(newBlock);
-      logger.debug('Block linked successfully');
-
+      logger.debug('Existing item linked (pending save)', { itemId, area });
     } catch (err: any) {
       logger.error('Failed to link item:', err);
-      logger.error('Error details:', {
-        message: err.message,
-        response: err.response?.data,
-        status: err.response?.status
-      });
       throw err;
     }
   }
 
   /**
-   * Duplicate an existing item and link it to the current record
+   * Duplicate an existing item as a new inline block (persisted on global Save).
    */
   async function duplicateExistingItem(
     area: string,
     targetCollection: string,
     itemData: any
   ): Promise<void> {
-    if (!junctionInfo.value) {
-      throw new Error('Junction info not available');
-    }
+    const itemCopy = cloneDeep(itemData) as Record<string, any>;
 
-    const pk = unref(primaryKey);
-    if (!pk || pk === '+' || pk === 'new') {
-      throw new Error('Cannot duplicate items to unsaved record');
-    }
-
-    try {
-      logger.debug('Duplicating existing item', {
-        area,
-        targetCollection,
-        originalItemId: itemData.id
-      });
-
-      // Deep clone the item data
-      const itemCopy = JSON.parse(JSON.stringify(itemData));
-      
-      // Remove system metadata fields (based on expandable-blocks pattern)
-      const metadataFields = ['id', 'user_created', 'user_updated', 'date_created', 'date_updated'];
-      for (const field of metadataFields) {
-        delete itemCopy[field];
+    for (const f of METADATA_FIELDS) delete itemCopy[f];
+    for (const f of TITLE_FIELDS) {
+      if (itemCopy[f] && typeof itemCopy[f] === 'string') {
+        itemCopy[f] += ' (Copy)';
+        break;
       }
-      
-      // Add suffix to title fields (based on expandable-blocks pattern)
-      const titleFields = ['title', 'name', 'headline', 'label', 'heading'];
-      for (const field of titleFields) {
-        if (itemCopy[field] && typeof itemCopy[field] === 'string') {
-          itemCopy[field] += ' (Copy)';
-          break; // Only add to first found field
-        }
-      }
-
-      logger.debug('Creating duplicated item', { targetCollection });
-
-      // Create the new item in the target collection
-      const itemResponse = await api.post(`/items/${targetCollection}`, itemCopy);
-      const newItemId = itemResponse.data.data.id;
-      logger.debug('Duplicated item created', { id: newItemId });
-
-      // Link the duplicated item
-      await linkExistingItem(area, targetCollection, newItemId);
-
-    } catch (err: any) {
-      logger.error('Failed to duplicate item', err);
-      logger.error('Error details:', {
-        message: err.message,
-        response: err.response?.data,
-        status: err.response?.status
-      });
-      throw err;
     }
+
+    const newBlock: BlockItem = {
+      id: generateTempId('dup'),
+      area,
+      sort: nextSortFor(area),
+      collection: targetCollection,
+      item: itemCopy
+    };
+    blocks.value.push(newBlock);
+    logger.debug('Item duplicated (pending save)', { area });
   }
 
   /**
-   * Update a block's area and/or sort position
+   * Update a block's area and/or sort position (state only).
    */
   async function updateBlock(
-    blockId: number,
+    blockId: BlockId,
     updates: { area?: string; sort?: number }
   ): Promise<void> {
-    if (!junctionInfo.value) {
-      throw new Error('Junction info not available');
-    }
+    const block = blocks.value.find(b => b.id === blockId);
+    if (!block) return;
 
-    try {
-      const updateData: any = {};
-      
-      if (updates.area !== undefined && junctionInfo.value.hasAreaField) {
-        updateData[areaField.value] = updates.area;
-      }
-      if (updates.sort !== undefined && junctionInfo.value.hasSortField) {
-        updateData[sortField.value] = updates.sort;
-      }
-
-      // Update the junction record
-      await api.patch(
-        `/items/${junctionInfo.value.collection}/${blockId}`,
-        updateData
-      );
-
-      // Update local state
-      const block = blocks.value.find(b => b.id === blockId);
-      if (block) {
-        if (updates.area !== undefined) block.area = updates.area;
-        if (updates.sort !== undefined) block.sort = updates.sort;
-      }
-
-      logger.debug('Block updated successfully');
-
-    } catch (err: any) {
-      logger.error('Failed to update block:', err);
-      throw err;
-    }
+    if (updates.area !== undefined) block.area = updates.area;
+    if (updates.sort !== undefined) block.sort = updates.sort;
+    markBlockDirty(blockId, true);
   }
 
   /**
-   * Unlink a block (remove junction only, keep content item)
+   * Unlink a block (remove from the layout; the junction is deleted on save).
+   * The content item is preserved.
    */
-  async function unlinkBlock(blockId: number): Promise<void> {
-    if (!junctionInfo.value) {
-      throw new Error('Junction info not available');
-    }
+  async function unlinkBlock(blockId: BlockId): Promise<void> {
+    const block = blocks.value.find(b => b.id === blockId);
+    if (!block) throw new Error('Block not found');
 
-    try {
-      const block = blocks.value.find(b => b.id === blockId);
-      if (!block) {
-        throw new Error('Block not found');
-      }
+    const area = block.area;
+    // Removing the block from the emitted array makes Directus delete the
+    // junction row on save (structured-deferred deletion).
+    blocks.value = blocks.value.filter(b => b.id !== blockId);
+    dirtyIds.value.delete(blockId);
 
-      // Only delete the junction record (not the content item)
-      await api.delete(`/items/${junctionInfo.value.collection}/${blockId}`);
-
-      // Remove from local state
-      blocks.value = blocks.value.filter(b => b.id !== blockId);
-      
-      // Update sort values for remaining blocks in the same area
-      const remainingBlocks = blocks.value.filter(b => b.area === block.area);
-      remainingBlocks.sort((a, b) => a.sort - b.sort);
-      remainingBlocks.forEach((b, index) => {
+    // Renumber the remaining blocks in the area with clean integer sorts.
+    const remaining = blocks.value.filter(b => b.area === area).sort((a, b) => a.sort - b.sort);
+    remaining.forEach((b, index) => {
+      if (b.sort !== index) {
         b.sort = index;
-      });
+        markBlockDirty(b.id, true);
+      }
+    });
 
-      logger.debug('Block unlinked successfully');
-
-    } catch (err: any) {
-      logger.error('Failed to unlink block:', err);
-      throw err;
-    }
+    logger.debug('Block unlinked (pending save)', { blockId });
   }
 
   /**
-   * Delete a block (with option to delete content item)
+   * Delete a block. The junction removal is deferred to global Save. When
+   * `deleteItem` is requested, the underlying content item is deleted
+   * immediately (an explicit destructive "delete everywhere" action that the
+   * M2A form value cannot express).
    */
-  async function deleteBlock(blockId: number, deleteItem = false): Promise<void> {
-    if (!junctionInfo.value) {
-      throw new Error('Junction info not available');
+  async function deleteBlock(blockId: BlockId, deleteItem = false): Promise<void> {
+    const block = blocks.value.find(b => b.id === blockId);
+    if (!block) throw new Error('Block not found');
+
+    if (deleteItem && block.item?.id && !isTempId(blockId)) {
+      await api.delete(`/items/${block.collection}/${block.item.id}`);
+      logger.debug('Content item deleted', { collection: block.collection, id: block.item.id });
     }
 
-    try {
-      const block = blocks.value.find(b => b.id === blockId);
-      if (!block) {
-        throw new Error('Block not found');
-      }
-
-      // Delete the item first if requested
-      if (deleteItem && block.item?.id) {
-        await api.delete(`/items/${block.collection}/${block.item.id}`);
-      }
-
-      // Delete the junction record
-      await api.delete(`/items/${junctionInfo.value.collection}/${blockId}`);
-
-      // Remove from local state
-      blocks.value = blocks.value.filter(b => b.id !== blockId);
-      logger.debug('Block deleted successfully');
-
-    } catch (err: any) {
-      logger.error('Failed to delete block:', err);
-      throw err;
-    }
+    await unlinkBlock(blockId);
+    logger.debug('Block deleted (junction pending save)', { blockId });
   }
 
   /**
-   * Reorder blocks within an area
+   * Reorder blocks within an area (state only). Assigns sequential integer sort
+   * values to keep the junction `sort` column integral (fix #42).
    */
-  async function reorderBlocks(
-    area: string,
-    blockIds: number[]
-  ): Promise<void> {
-    if (!junctionInfo.value || !junctionInfo.value.hasSortField) {
-      logger.warn('Cannot reorder: sort field not available');
-      return;
-    }
-
-    try {
-      // Update sort values
-      const updates = blockIds.map((id, index) => ({
-        id,
-        [sortField.value]: index
-      }));
-
-      // Batch update
-      for (const update of updates) {
-        await api.patch(
-          `/items/${junctionInfo.value.collection}/${update.id}`,
-          { [sortField.value]: update[sortField.value] }
-        );
-
-        // Update local state
-        const block = blocks.value.find(b => b.id === update.id);
-        if (block) {
-          block.sort = update[sortField.value];
-        }
+  async function reorderBlocks(area: string, blockIds: BlockId[]): Promise<void> {
+    blockIds.forEach((id, index) => {
+      const block = blocks.value.find(b => b.id === id);
+      if (block && block.sort !== index) {
+        block.sort = index;
+        markBlockDirty(id, true);
       }
-
-      logger.debug('Blocks reordered successfully');
-
-    } catch (err: any) {
-      logger.error('Failed to reorder blocks:', err);
-      throw err;
-    }
+    });
+    logger.debug('Blocks reordered (pending save)', { area });
   }
 
   /**
-   * Move block to a different area
+   * Move a block to a different area at a drop index (state only).
    */
   async function moveBlock(
-    blockId: number,
+    blockId: BlockId,
     targetArea: string,
     targetIndex?: number
   ): Promise<void> {
     const block = blocks.value.find(b => b.id === blockId);
-    if (!block) {
-      throw new Error('Block not found');
-    }
+    if (!block) throw new Error('Block not found');
 
-    // Build the target area's order without the moved block, then insert it at
-    // the drop index. We renumber the whole area with sequential integer sort
-    // values (via reorderBlocks) instead of computing fractional midpoints,
-    // which the integer `sort` column rejects (e.g. a midpoint like -4.5 caused
-    // a 500 on the junction update).
+    // Build the target area order without the moved block, insert at the drop
+    // index, then renumber with sequential integers (see fix #40/#42).
     const orderedIds = getBlocksForArea(targetArea)
       .filter(b => b.id !== blockId)
       .map(b => b.id);
@@ -460,18 +345,71 @@ export function useBlocks(
       : orderedIds.length;
     orderedIds.splice(insertAt, 0, blockId);
 
-    // Apply the area change first, then renumber the target area with clean
-    // integer sort values.
     if (block.area !== targetArea) {
       await updateBlock(blockId, { area: targetArea });
     }
     await reorderBlocks(targetArea, orderedIds);
   }
 
+  /**
+   * Build the Directus M2A field value for global Save.
+   *
+   * Per array element:
+   * - clean existing block  → bare junction id (number)
+   * - dirty existing block  → full junction object with nested item (deep update)
+   * - linked existing item  → junction object, item = bare PK (source not mutated)
+   * - new block             → junction object, nested item without id (create)
+   * - deleted/unlinked      → simply absent from the array (Directus deletes it)
+   */
+  function prepareItemsForEmit(): any[] {
+    const info = junctionInfo.value;
+    if (!info) {
+      // Without resolved junction info we cannot shape the value safely.
+      return blocks.value.map(b => b.id);
+    }
+
+    const collectionField = info.collectionField;
+    const itemField = info.itemField;
+    const hasArea = info.hasAreaField;
+    const hasSort = info.hasSortField;
+
+    return blocks.value.map((block) => {
+      const temp = isTempId(block.id);
+      const dirty = temp || dirtyIds.value.has(block.id);
+
+      // Clean, persisted block → emit the bare id.
+      if (!dirty) {
+        return block.id;
+      }
+
+      const junction: Record<string, any> = {
+        [collectionField]: block.collection
+      };
+      if (!temp) junction.id = block.id;
+      if (hasArea) junction[areaField.value] = block.area;
+      if (hasSort) junction[sortField.value] = block.sort;
+
+      if (isExistingLink(block.id)) {
+        // Link to existing item → bare PK only.
+        junction[itemField] = block.item?.id ?? block.item;
+      } else if (temp) {
+        // Truly new content → nested object without an id (create).
+        const { id: _omitId, ...itemData } = block.item || {};
+        junction[itemField] = itemData;
+      } else {
+        // Existing block with edited content → nested object with id (deep update).
+        junction[itemField] = block.item;
+      }
+
+      return junction;
+    });
+  }
+
   return {
     blocks: computed(() => blocks.value),
     loading: computed(() => loading.value),
     error: computed(() => error.value),
+    isInternalUpdate,
     loadBlocks,
     getBlocksForArea,
     addBlock,
@@ -481,6 +419,8 @@ export function useBlocks(
     unlinkBlock,
     deleteBlock,
     reorderBlocks,
-    moveBlock
+    moveBlock,
+    markBlockDirty,
+    prepareItemsForEmit
   };
 }

--- a/src/composables/useDragDrop.ts
+++ b/src/composables/useDragDrop.ts
@@ -1,10 +1,10 @@
 import { ref, type Ref } from 'vue';
-import type { BlockItem, AreaConfig } from '../types';
+import type { BlockItem, BlockId, AreaConfig } from '../types';
 import { createDragImage } from '../utils/blockHelpers';
 
 export interface DragDropOptions {
   onMove: (data: {
-    blockId: number;
+    blockId: BlockId;
     fromArea: string;
     toArea: string;
     toIndex: number;

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -254,13 +254,15 @@ import { useBlocks } from './composables/useBlocks';
 import { usePermissions } from './composables/usePermissions';
 import { useBlockPermissions } from './composables/useBlockPermissions';
 import { DEFAULT_OPTIONS, DEFAULT_AREA_CONFIG } from './utils/constants';
-import { normalizeAreaIds } from './utils/helpers';
+import { normalizeAreaIds, isTempId } from './utils/helpers';
+import { cloneDeep } from 'lodash-es';
 import { CUSTOM_AREAS, USE_CUSTOM_AREAS } from './config/areas';
-import type { 
-  LayoutBlocksOptions, 
-  JunctionInfo, 
+import type {
+  LayoutBlocksOptions,
+  JunctionInfo,
   BlockItem,
-  AreaConfig 
+  BlockId,
+  AreaConfig
 } from './types';
 
 // Import components (we'll create these next)
@@ -425,6 +427,7 @@ const showItemSelector = ref(false);
 const selectedCollection = ref<string>('');
 const drawerActive = ref(false);
 const editingId = ref<string | number | null>(null);
+const editingBlockId = ref<BlockId | null>(null);
 const editingCollection = ref<string>('');
 const editingValues = ref<any>({});
 
@@ -550,7 +553,10 @@ const {
   unlinkBlock,
   deleteBlock,
   reorderBlocks,
-  moveBlock
+  moveBlock,
+  markBlockDirty,
+  isInternalUpdate,
+  prepareItemsForEmit
 } = useBlocks(
   props.collection!,
   props.field!,
@@ -1148,13 +1154,14 @@ async function handleItemSelectorDuplicated(items: any[]) {
 }
 
 async function handleMoveBlock(data: {
-  blockId: number;
+  blockId: BlockId;
   fromArea: string;
   toArea: string;
   toIndex: number;
 }) {
-  // Find the block to get its collection
-  const block = blocks.value.find(b => b.id === data.blockId);
+  // Compare as strings: drag payloads from the DOM are strings, while persisted
+  // blocks carry numeric ids (see fix #40/#42).
+  const block = blocks.value.find(b => String(b.id) === String(data.blockId));
   if (!block) {
     logger.error('Block not found for move:', data.blockId);
     return;
@@ -1176,7 +1183,7 @@ async function handleMoveBlock(data: {
   
   try {
     await moveBlock(
-      data.blockId,
+      block.id,
       data.toArea,
       data.toIndex
     );
@@ -1204,35 +1211,29 @@ async function handleUpdateBlock(data: {
   }
   
   try {
-    // Find the block to get its collection and item ID
+    // Find the block to get its collection and item id
     const block = blocks.value.find(b => b.id === data.blockId);
     if (!block) {
       throw new Error('Block not found');
     }
-    
-    if (!block.item?.id) {
-      throw new Error('Block item ID not found');
-    }
-    
-    logger.log('🔵 Opening Directus drawer for:', {
-      collection: block.collection,
-      itemId: block.item.id
-    });
-    
-    // Set the editing info
+
     editingCollection.value = block.collection;
-    editingId.value = block.item.id;
-    
-    // Load the current values for the form
-    logger.log('🔵 Loading block data for edit');
-    const response = await api.get(`/items/${block.collection}/${block.item.id}`);
-    editingValues.value = response.data.data;
-    
-    logger.log('🔵 Opening drawer with data:', editingValues.value);
-    
+    editingBlockId.value = block.id;
+
+    if (isTempId(block.id) || !block.item?.id) {
+      // Unsaved block: edit its inline content in create mode (no API item yet).
+      editingId.value = '+';
+      editingValues.value = cloneDeep(block.item || {});
+    } else {
+      // Persisted block: load current item values read-only for the form.
+      editingId.value = block.item.id;
+      const response = await api.get(`/items/${block.collection}/${block.item.id}`);
+      editingValues.value = response.data.data;
+    }
+
     // Open drawer
     drawerActive.value = true;
-    
+
   } catch (error) {
     logger.error('🔴 Error opening editor:', error);
     notifications.add({
@@ -1243,49 +1244,26 @@ async function handleUpdateBlock(data: {
   }
 }
 
-async function handleBlockStatusUpdate(blockId: number, newStatus: string) {
+async function handleBlockStatusUpdate(blockId: BlockId, newStatus: string) {
   logger.log('🔵 Updating block status:', blockId, 'to', newStatus);
-  
-  try {
-    // Find the block
-    const block = blocks.value.find(b => b.id === blockId);
-    if (!block) {
-      throw new Error('Block not found');
-    }
-    
-    if (!block.item?.id) {
-      throw new Error('Block item ID not found');
-    }
-    
-    // Send PATCH request to update status
-    await api.patch(`/items/${block.collection}/${block.item.id}`, {
-      status: newStatus
-    });
-    
-    logger.log('✅ Status updated successfully');
-    
-    notifications.add({
-      title: 'Status Updated',
-      text: `Block status changed to ${newStatus}`,
-      type: 'success'
-    });
-    
-    // Update local block data
-    if (block.item) {
-      block.item.status = newStatus;
-    }
-    
-    // Reload blocks to ensure consistency
-    await loadBlocks();
-    
-  } catch (error: any) {
-    logger.error('🔴 Error updating status:', error);
-    notifications.add({
-      title: 'Error Updating Status',
-      text: error.message || 'Failed to update block status',
-      type: 'error'
-    });
+
+  const block = blocks.value.find(b => b.id === blockId);
+  if (!block) {
+    logger.error('🔴 Block not found for status update:', blockId);
+    return;
   }
+
+  // Stage the status change locally; persisted on global Save.
+  if (block.item) {
+    block.item.status = newStatus;
+  }
+  markBlockDirty(blockId, true);
+
+  notifications.add({
+    title: 'Status Updated',
+    text: `Block status changed to ${newStatus}`,
+    type: 'success'
+  });
 }
 
 // Helper to check if a field exists in the current collection
@@ -1371,46 +1349,37 @@ function getFieldOptions(field: any): any[] {
   return [];
 }
 
-// Save block directly via API
+// Stage drawer edits into block state (persisted on global Save).
 async function saveBlockDirectly() {
-  if (!editingId.value || !editingCollection.value || !editingValues.value) return;
-  
+  if (!editingCollection.value || editingBlockId.value === null) return;
+
   editSaving.value = true;
-  
+
   try {
-    logger.log('💾 Saving block directly to API:', {
-      collection: editingCollection.value,
-      id: editingId.value,
-      values: editingValues.value
-    });
-    
-    // Send PATCH request to update the item
-    await api.patch(`/items/${editingCollection.value}/${editingId.value}`, editingValues.value);
-    
-    logger.log('✅ Block saved successfully');
-    
+    const block = blocks.value.find(b => b.id === editingBlockId.value);
+    if (block) {
+      block.item = { ...block.item, ...editingValues.value };
+      markBlockDirty(block.id, true);
+    }
+
     notifications.add({
       title: 'Block Updated',
-      text: 'Changes have been saved successfully',
+      text: 'Changes staged — use Save to persist',
       type: 'success'
     });
-    
-    // Close drawer
+
+    // Close drawer + reset editing state
     drawerActive.value = false;
-    
-    // Reset editing state
     editingId.value = null;
+    editingBlockId.value = null;
     editingCollection.value = '';
     editingValues.value = {};
-    
-    // Reload blocks to show changes
-    await loadBlocks();
-    
+
   } catch (error: any) {
-    logger.error('🔴 Error saving block:', error);
+    logger.error('🔴 Error staging block changes:', error);
     notifications.add({
       title: 'Error Saving Block',
-      text: error.message || 'Failed to save block',
+      text: error.message || 'Failed to stage block changes',
       type: 'error'
     });
   } finally {
@@ -1422,6 +1391,7 @@ async function saveBlockDirectly() {
 function handleDrawerCancel() {
   drawerActive.value = false;
   editingId.value = null;
+  editingBlockId.value = null;
   editingCollection.value = '';
   editingValues.value = {};
 }
@@ -1436,13 +1406,13 @@ const foreignKeyField = computed(() => {
 });
 
 
-async function handleRemoveBlock(blockId: number) {
+async function handleRemoveBlock(blockId: BlockId) {
   // This is now just for backward compatibility
   // The actual unlink/delete is handled by separate methods
   await handleUnlinkBlock(blockId);
 }
 
-async function handleUnlinkBlock(blockId: number) {
+async function handleUnlinkBlock(blockId: BlockId) {
   try {
     await unlinkBlock(blockId);
     
@@ -1460,7 +1430,7 @@ async function handleUnlinkBlock(blockId: number) {
   }
 }
 
-async function handleDeleteBlock(blockId: number, deleteContent: boolean) {
+async function handleDeleteBlock(blockId: BlockId, deleteContent: boolean) {
   try {
     await deleteBlock(blockId, deleteContent);
     
@@ -1480,7 +1450,7 @@ async function handleDeleteBlock(blockId: number, deleteContent: boolean) {
   }
 }
 
-async function handleDuplicateBlock(blockId: number) {
+async function handleDuplicateBlock(blockId: BlockId) {
   try {
     blocksLoading.value = true;
     
@@ -1562,66 +1532,13 @@ async function handleAreasUpdate(updatedAreas: AreaConfig[]) {
       logger.log('Interface: Will move blocks to "orphaned" area');
       
       for (const block of blocksToOrphan) {
-        logger.log(`Interface: Processing block ${block.id} for orphaning`);
-        try {
-          // Update the junction record to remove its area assignment
-          // We need to update the junction table, not the content item
-          if (!junctionInfo.value) {
-            logger.error('Interface: No junction info available for orphaning!');
-            continue;
-          }
-          
-          const areaField = options.value.areaField || 'area';
-          // Instead of setting to null, move to 'orphaned' area
-          const updateData = { [areaField]: 'orphaned' };
-          
-          logger.log(`Interface: Preparing to orphan block ${block.id}`, {
-            collection: junctionInfo.value.collection,
-            blockId: block.id,
-            blockData: block,
-            areaField: areaField,
-            updateData: updateData
-          });
-            
-            try {
-              const response = await api.patch(
-                `/items/${junctionInfo.value.collection}/${block.id}`,
-                updateData
-              );
-              
-              logger.log(`Interface: Block ${block.id} orphaned successfully`, response);
-              
-              // Update local state immediately
-              const blockIndex = blocks.value.findIndex(b => b.id === block.id);
-              if (blockIndex !== -1) {
-                blocks.value[blockIndex].area = 'orphaned';
-              }
-            } catch (patchError: any) {
-              logger.error(`Interface: PATCH request failed:`, {
-                url: `/items/${junctionInfo.value.collection}/${block.id}`,
-                updateData: updateData,
-                error: patchError,
-                status: patchError.response?.status,
-                statusText: patchError.response?.statusText,
-                responseData: patchError.response?.data,
-                message: patchError.message
-              });
-              throw patchError;
-            }
-        } catch (error: any) {
-          logger.error(`Interface: Error orphaning block ${block.id}:`);
-          logger.error('Full error object:', error);
-          logger.error('Error message:', error?.message);
-          
-          // Most importantly, check the API response
-          if (error?.response?.data) {
-            logger.error('API Error Response:', error.response.data);
-            if (error.response.data.errors) {
-              error.response.data.errors.forEach((err: any) => {
-                logger.error('API Error Detail:', err);
-              });
-            }
-          }
+        // Stage the orphaning locally; persisted on global Save (no immediate
+        // write — keeps the form in a single consistent, discardable state).
+        const blockIndex = blocks.value.findIndex(b => b.id === block.id);
+        if (blockIndex !== -1) {
+          blocks.value[blockIndex].area = 'orphaned';
+          markBlockDirty(block.id, true);
+          logger.log(`Interface: Block ${block.id} staged for orphaning`);
         }
       }
       
@@ -1693,16 +1610,26 @@ function saveAreas() {
   // and then close itself, which will set showAreaManager to false
 }
 
-// Watch for external value changes
-watch(() => props.value, (newValue) => {
-  if (JSON.stringify(newValue) !== JSON.stringify(blocks.value)) {
-    loadBlocks();
-  }
+// Emit block changes into the Directus form state so the global Save / Discard
+// buttons control persistence. `prepareItemsForEmit` shapes the M2A value
+// (bare ids for clean blocks, full objects for dirty/new). Guarded against our
+// own programmatic updates (loadBlocks / post-emit) to avoid feedback loops.
+watch(blocks, () => {
+  if (isInternalUpdate.value) return;
+  isInternalUpdate.value = true;
+  emit('input', prepareItemsForEmit());
+  nextTick(() => {
+    isInternalUpdate.value = false;
+  });
 }, { deep: true });
 
-// Emit changes
-watch(blocks, (newBlocks) => {
-  emit('input', newBlocks);
+// React to external value changes. After Save the value returns the persisted
+// ids; after Discard it reverts to the last saved value. In both cases the
+// database holds the truth (nothing is written mid-session), so we reload
+// read-only and reset the dirty baseline. Skipped for our own emits.
+watch(() => props.value, () => {
+  if (isInternalUpdate.value) return;
+  loadBlocks();
 }, { deep: true });
 </script>
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,8 +51,15 @@ export interface JunctionInfo {
   allowedCollections?: string[];
 }
 
+/**
+ * Junction record identifier. Persisted blocks carry the numeric junction PK;
+ * unsaved blocks carry a temporary string id (`new_`/`dup_`/`existing_` prefix)
+ * until the global Save resolves them to a real PK.
+ */
+export type BlockId = number | string;
+
 export interface BlockItem {
-  id: number;
+  id: BlockId;
   area: string;
   sort: number;
   collection: string;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -20,18 +20,35 @@ export function isNotNullish(value: any): boolean {
   return value !== null && value !== undefined;
 }
 
+// Temporary-id prefixes used before the global Save assigns real junction PKs.
+// `new`  = a brand-new block (content created inline), `dup` = duplicated item,
+// `existing` = a link to an already-existing item, `temp`/`idx` = legacy/fallback.
+const TEMP_ID_PREFIXES = ['new', 'dup', 'existing', 'temp', 'idx'] as const;
+
+export type TempIdKind = 'new' | 'dup' | 'existing';
+
 /**
- * Generate a unique ID for temporary items
+ * Generate a unique temporary id for an unsaved block.
+ * The kind prefix lets {@link isExistingLink} distinguish linked items (whose
+ * source content must NOT be rewritten) from genuinely new content.
  */
-export function generateTempId(): string {
-  return `temp_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+export function generateTempId(kind: TempIdKind = 'new'): string {
+  return `${kind}_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
 }
 
 /**
- * Check if an ID is a temporary ID
+ * Check if an id is a temporary (unsaved) id.
  */
-export function isTempId(id: any): boolean {
-  return typeof id === 'string' && id.startsWith('temp_');
+export function isTempId(id: unknown): boolean {
+  return typeof id === 'string' && TEMP_ID_PREFIXES.some(p => id.startsWith(`${p}_`));
+}
+
+/**
+ * Check if an id refers to a link to an existing item (`existing_` prefix).
+ * Such blocks must emit only the bare item PK so the source item is not mutated.
+ */
+export function isExistingLink(id: unknown): boolean {
+  return typeof id === 'string' && id.startsWith('existing_');
 }
 
 /**

--- a/test/unit/composables/useBlockPermissions.test.ts
+++ b/test/unit/composables/useBlockPermissions.test.ts
@@ -201,10 +201,10 @@ describe('useBlockPermissions Composable', () => {
       let result = validation.validateMoveBlock('main', 'sidebar', 'content_text');
       expect(result.valid).toBe(true);
       
-      // Without update permission
+      // Since #40 moving only updates the junction row's area/sort; authorization
+      // is enforced server-side, so the client-side gate always passes.
       result = validation.validateMoveBlock('main', 'sidebar', 'content_image');
-      expect(result.valid).toBe(false);
-      expect(result.error).toContain('do not have permission to move');
+      expect(result.valid).toBe(true);
     });
 
     it('should validate delete permissions', () => {

--- a/test/unit/composables/useBlocks.test.ts
+++ b/test/unit/composables/useBlocks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ref, computed, nextTick } from 'vue';
+import { computed, nextTick } from 'vue';
 
 // First set up all mocks before importing the module that uses them
 const mockApi = {
@@ -48,14 +48,22 @@ vi.mock('../../../src/utils/m2a-helper', () => ({
 
 // Now import the module after mocks are set up
 import { useBlocks } from '../../../src/composables/useBlocks';
+import { M2AHelper } from '../../../src/utils/m2a-helper';
+import { isTempId, isExistingLink } from '../../../src/utils/helpers';
 
-describe('useBlocks Composable', () => {
+describe('useBlocks Composable (global-save / state-based)', () => {
   let junctionInfo: any;
   let options: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    
+    // The vitest config enables mockReset/restoreMocks, which wipes mock
+    // implementations before each test — re-establish the M2AHelper constructor
+    // so `new M2AHelper()` keeps returning our stub.
+    (M2AHelper as unknown as { mockImplementation: (fn: () => any) => void })
+      .mockImplementation(() => mockM2AHelper);
+    mockM2AHelper.loadM2AData.mockResolvedValue([]);
+
     junctionInfo = computed(() => ({
       collection: 'page_blocks',
       primaryKeyField: 'id',
@@ -73,283 +81,213 @@ describe('useBlocks Composable', () => {
     }));
   });
 
-  describe('linkExistingItem', () => {
-    it('should link an existing item successfully', async () => {
-      const primaryKey = computed(() => 1);
-      
-      mockApi.post.mockResolvedValueOnce({
-        data: { data: { id: 100 } }
-      });
-      
-      mockApi.get.mockResolvedValueOnce({
-        data: { data: { id: 1, title: 'Test Item' } }
-      });
+  function setup(primaryKeyValue: string | number = 1) {
+    return useBlocks('pages', 'blocks', computed(() => primaryKeyValue), junctionInfo, options);
+  }
 
-      const { linkExistingItem, blocks } = useBlocks(
-        'pages',
-        'blocks',
-        primaryKey,
-        junctionInfo,
-        options
-      );
+  /**
+   * Seed the composable's internal `blocks` via loadBlocks() + the mocked
+   * M2AHelper, then await the flush so state is populated.
+   */
+  async function seed(blocks: any[]) {
+    mockM2AHelper.loadM2AData.mockResolvedValue(blocks);
+    const api = setup(1);
+    await api.loadBlocks();
+    await nextTick();
+    return api;
+  }
 
-      await linkExistingItem('main', 'content_text', 1);
+  const baseRecord = (over: Partial<any> = {}) => ({
+    id: 10,
+    area: 'main',
+    sort: 0,
+    collection: 'content_text',
+    item: { id: 5, title: 'A' },
+    ...over
+  });
 
-      // Check that junction record was created
-      expect(mockApi.post).toHaveBeenCalledWith(
-        '/items/page_blocks',
-        expect.objectContaining({
-          page_id: 1,
-          item: 1,
-          collection: 'content_text',
-          area: 'main',
-          sort: 0
-        })
-      );
+  describe('addBlock (staged, no API write)', () => {
+    it('stages a new block with a temporary id and inline content', async () => {
+      const { addBlock, blocks } = setup(1);
 
-      // Check that item was fetched
-      expect(mockApi.get).toHaveBeenCalledWith('/items/content_text/1');
+      await addBlock('main', 'content_text', { title: 'New' });
 
-      // Check that block was added to local state
-      await nextTick();
-      expect(blocks.value).toContainEqual(
-        expect.objectContaining({
-          id: 100,
-          area: 'main',
-          sort: 0,
-          collection: 'content_text'
-        })
-      );
-    });
-
-    it('should throw error when trying to link to unsaved item', async () => {
-      const primaryKey = computed(() => '+');
-      
-      const { linkExistingItem } = useBlocks(
-        'pages',
-        'blocks',
-        primaryKey,
-        junctionInfo,
-        options
-      );
-
-      await expect(
-        linkExistingItem('main', 'content_text', 1)
-      ).rejects.toThrow('Cannot link items to unsaved record');
-    });
-
-    it('should throw error when junction info is not available', async () => {
-      const primaryKey = computed(() => 1);
-      const emptyJunctionInfo = computed(() => null);
-      
-      const { linkExistingItem } = useBlocks(
-        'pages',
-        'blocks',
-        primaryKey,
-        emptyJunctionInfo,
-        options
-      );
-
-      await expect(
-        linkExistingItem('main', 'content_text', 1)
-      ).rejects.toThrow('Junction info not available');
+      expect(mockApi.post).not.toHaveBeenCalled();
+      expect(blocks.value).toHaveLength(1);
+      const block = blocks.value[0];
+      expect(isTempId(block.id)).toBe(true);
+      expect(block.area).toBe('main');
+      expect(block.collection).toBe('content_text');
+      expect(block.item).toEqual({ title: 'New' });
     });
   });
 
-  describe('duplicateExistingItem', () => {
-    it('should duplicate an item successfully', async () => {
-      const primaryKey = computed(() => 1);
+  describe('linkExistingItem (staged, read-only fetch)', () => {
+    it('fetches the item read-only and stages an existing-link block', async () => {
+      mockApi.get.mockResolvedValueOnce({ data: { data: { id: 7, title: 'Linked' } } });
+      const { linkExistingItem, blocks } = setup(1);
+
+      await linkExistingItem('main', 'content_text', 7);
+
+      expect(mockApi.post).not.toHaveBeenCalled();
+      expect(mockApi.get).toHaveBeenCalledWith('/items/content_text/7');
+      expect(blocks.value).toHaveLength(1);
+      expect(isExistingLink(blocks.value[0].id)).toBe(true);
+      expect(blocks.value[0].item).toEqual({ id: 7, title: 'Linked' });
+    });
+  });
+
+  describe('duplicateExistingItem (staged, no API write)', () => {
+    it('strips metadata and adds a (Copy) suffix without writing', async () => {
+      const { duplicateExistingItem, blocks } = setup(1);
       const itemData = {
         id: 1,
-        title: 'Original Item',
-        content: 'Test content',
-        user_created: 'user1',
+        title: 'Original',
+        content: 'body',
+        user_created: 'u1',
         date_created: '2024-01-01'
       };
 
-      // Mock create new item
-      mockApi.post.mockResolvedValueOnce({
-        data: { data: { id: 2 } }
-      });
-      
-      // Mock create junction
-      mockApi.post.mockResolvedValueOnce({
-        data: { data: { id: 101 } }
-      });
-      
-      // Mock get item
-      mockApi.get.mockResolvedValueOnce({
-        data: { data: { id: 2, title: 'Original Item (Copy)' } }
-      });
-
-      const { duplicateExistingItem, blocks } = useBlocks(
-        'pages',
-        'blocks',
-        primaryKey,
-        junctionInfo,
-        options
-      );
-
       await duplicateExistingItem('main', 'content_text', itemData);
 
-      // Check that item was created without metadata fields
-      expect(mockApi.post).toHaveBeenCalledWith(
-        '/items/content_text',
-        expect.objectContaining({
-          title: 'Original Item (Copy)',
-          content: 'Test content'
-        })
-      );
-
-      // Verify metadata fields were removed
-      const callData = mockApi.post.mock.calls[0][1];
-      expect(callData).not.toHaveProperty('id');
-      expect(callData).not.toHaveProperty('user_created');
-      expect(callData).not.toHaveProperty('date_created');
+      expect(mockApi.post).not.toHaveBeenCalled();
+      expect(blocks.value).toHaveLength(1);
+      const item = blocks.value[0].item;
+      expect(item.title).toBe('Original (Copy)');
+      expect(item.content).toBe('body');
+      expect(item).not.toHaveProperty('id');
+      expect(item).not.toHaveProperty('user_created');
+      expect(item).not.toHaveProperty('date_created');
     });
 
-    it('should add suffix to title fields when duplicating', async () => {
-      const primaryKey = computed(() => 1);
-      const testCases = [
-        { field: 'title', value: 'Test' },
-        { field: 'name', value: 'Test' },
-        { field: 'headline', value: 'Test' },
-        { field: 'label', value: 'Test' },
-        { field: 'heading', value: 'Test' }
-      ];
-
-      for (const testCase of testCases) {
-        vi.clearAllMocks();
-        
-        const itemData = {
-          id: 1,
-          [testCase.field]: testCase.value
-        };
-
-        mockApi.post.mockResolvedValueOnce({
-          data: { data: { id: 2 } }
-        });
-        mockApi.post.mockResolvedValueOnce({
-          data: { data: { id: 101 } }
-        });
-        mockApi.get.mockResolvedValueOnce({
-          data: { data: { id: 2 } }
-        });
-
-        const { duplicateExistingItem } = useBlocks(
-          'pages',
-          'blocks',
-          primaryKey,
-          junctionInfo,
-          options
-        );
-
-        await duplicateExistingItem('main', 'content_text', itemData);
-
-        expect(mockApi.post).toHaveBeenCalledWith(
-          '/items/content_text',
-          expect.objectContaining({
-            [testCase.field]: `${testCase.value} (Copy)`
-          })
-        );
+    it.each(['title', 'name', 'headline', 'label', 'heading'])(
+      'adds the (Copy) suffix to the %s field',
+      async (field) => {
+        const { duplicateExistingItem, blocks } = setup(1);
+        await duplicateExistingItem('main', 'content_text', { id: 1, [field]: 'Test' });
+        expect(blocks.value[0].item[field]).toBe('Test (Copy)');
       }
+    );
+  });
+
+  describe('updateBlock / reorderBlocks / moveBlock (state only)', () => {
+    it('updateBlock mutates area/sort and marks dirty', async () => {
+      const { updateBlock, blocks } = await seed([baseRecord()]);
+      await updateBlock(10, { area: 'sidebar', sort: 3 });
+      expect(mockApi.patch).not.toHaveBeenCalled();
+      expect(blocks.value[0].area).toBe('sidebar');
+      expect(blocks.value[0].sort).toBe(3);
+    });
+
+    it('reorderBlocks assigns sequential integer sorts (fix #42)', async () => {
+      const { reorderBlocks, blocks } = await seed([
+        baseRecord({ id: 10, sort: 0 }),
+        baseRecord({ id: 11, sort: 1, item: { id: 6, title: 'B' } })
+      ]);
+      await reorderBlocks('main', [11, 10]);
+      expect(mockApi.patch).not.toHaveBeenCalled();
+      expect(blocks.value.find(b => b.id === 11)!.sort).toBe(0);
+      expect(blocks.value.find(b => b.id === 10)!.sort).toBe(1);
+    });
+
+    it('moveBlock changes the area and keeps integer sorts', async () => {
+      const { moveBlock, blocks } = await seed([baseRecord({ id: 10, area: 'main', sort: 0 })]);
+      await moveBlock(10, 'sidebar', 0);
+      expect(mockApi.patch).not.toHaveBeenCalled();
+      const moved = blocks.value.find(b => b.id === 10)!;
+      expect(moved.area).toBe('sidebar');
+      expect(Number.isInteger(moved.sort)).toBe(true);
+    });
+  });
+
+  describe('unlinkBlock / deleteBlock', () => {
+    it('unlinkBlock removes the block from state without an API call', async () => {
+      const { unlinkBlock, blocks } = await seed([baseRecord()]);
+      await unlinkBlock(10);
+      expect(mockApi.delete).not.toHaveBeenCalled();
+      expect(blocks.value).toHaveLength(0);
+    });
+
+    it('deleteBlock(deleteItem=true) deletes the content item immediately, junction deferred', async () => {
+      mockApi.delete.mockResolvedValueOnce({});
+      const { deleteBlock, blocks } = await seed([baseRecord()]);
+      await deleteBlock(10, true);
+      expect(mockApi.delete).toHaveBeenCalledWith('/items/content_text/5');
+      expect(blocks.value).toHaveLength(0);
+    });
+
+    it('deleteBlock throws when the block is not found', async () => {
+      const { deleteBlock } = setup(1);
+      await expect(deleteBlock(999, true)).rejects.toThrow('Block not found');
     });
   });
 
   describe('loadBlocks', () => {
-    it('should handle loadBlocks for existing items', async () => {
-      const primaryKey = computed(() => 1);
-      
-      const { loadBlocks, loading } = useBlocks(
-        'pages',
-        'blocks',
-        primaryKey,
-        junctionInfo,
-        options
-      );
-      
-      // Loading should start as false
-      expect(loading.value).toBe(false);
-      
-      // loadBlocks should execute without errors
-      await expect(loadBlocks()).resolves.not.toThrow();
-    });
-
-    it('should skip loading for new items', async () => {
-      const primaryKey = computed(() => '+');
-      
-      const { loadBlocks, blocks } = useBlocks(
-        'pages',
-        'blocks',
-        primaryKey,
-        junctionInfo,
-        options
-      );
-
+    it('skips loading for new (unsaved) items', async () => {
+      const { loadBlocks, blocks } = setup('+');
       await loadBlocks();
-      
       expect(blocks.value).toEqual([]);
     });
   });
 
-  describe('getBlocksForArea', () => {
-    it('should return blocks filtered by area and sorted', () => {
-      const primaryKey = computed(() => 1);
-      
-      const { getBlocksForArea } = useBlocks(
-        'pages',
-        'blocks',
-        primaryKey,
-        junctionInfo,
-        options
-      );
-
-      // This test actually tests internal implementation
-      // In real usage, blocks would be loaded via loadBlocks
-      // For now, we'll test the function logic with mock data
-      const testBlocks = [
-        { id: 1, area: 'main', sort: 2, collection: 'content_text', item: {} },
-        { id: 2, area: 'sidebar', sort: 1, collection: 'content_image', item: {} },
-        { id: 3, area: 'main', sort: 1, collection: 'content_text', item: {} },
-        { id: 4, area: 'main', sort: 3, collection: 'content_image', item: {} }
-      ];
-
-      // Since getBlocksForArea filters internal blocks array,
-      // and we can't directly set it in the test, we'll skip this test
-      // or refactor the composable to allow testing
-      expect(true).toBe(true); // Placeholder assertion
-    });
-  });
-
-  describe('deleteBlock', () => {
-    it('should throw error when block not found', async () => {
-      const primaryKey = computed(() => 1);
-      
-      const { deleteBlock } = useBlocks(
-        'pages',
-        'blocks',
-        primaryKey,
-        junctionInfo,
-        options
-      );
-
-      // Try to delete non-existent block
-      await expect(deleteBlock(999, true)).rejects.toThrow('Block not found');
+  describe('prepareItemsForEmit (Directus M2A value shape)', () => {
+    it('emits a bare id for a clean, persisted block', async () => {
+      const { prepareItemsForEmit } = await seed([baseRecord()]);
+      expect(prepareItemsForEmit()).toEqual([10]);
     });
 
-    it('should throw error when junction info not available', async () => {
-      const primaryKey = computed(() => 1);
-      const emptyJunctionInfo = computed(() => null);
-      
-      const { deleteBlock } = useBlocks(
-        'pages',
-        'blocks',
-        primaryKey,
-        emptyJunctionInfo,
-        options
-      );
+    it('emits a full junction object (with nested item + area + sort) for a dirty block', async () => {
+      const { prepareItemsForEmit, markBlockDirty } = await seed([baseRecord()]);
+      markBlockDirty(10, true);
+      const out = prepareItemsForEmit();
+      expect(out[0]).toEqual({
+        id: 10,
+        collection: 'content_text',
+        area: 'main',
+        sort: 0,
+        item: { id: 5, title: 'A' }
+      });
+    });
 
-      await expect(deleteBlock(1, false)).rejects.toThrow('Junction info not available');
+    it('emits a nested item WITHOUT id for a brand-new block', async () => {
+      const { prepareItemsForEmit, addBlock } = await seed([]);
+      await addBlock('main', 'content_text', { title: 'New' });
+      const out = prepareItemsForEmit();
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatchObject({
+        collection: 'content_text',
+        area: 'main',
+        item: { title: 'New' }
+      });
+      expect(out[0]).not.toHaveProperty('id');
+      expect(out[0].item).not.toHaveProperty('id');
+    });
+
+    it('emits the bare item PK for a linked existing item (source not mutated)', async () => {
+      mockApi.get.mockResolvedValueOnce({ data: { data: { id: 7, title: 'Linked' } } });
+      const { prepareItemsForEmit, linkExistingItem } = await seed([]);
+      await linkExistingItem('main', 'content_text', 7);
+      const out = prepareItemsForEmit();
+      expect(out[0]).toMatchObject({ collection: 'content_text', area: 'main', item: 7 });
+      expect(out[0]).not.toHaveProperty('id');
+    });
+
+    it('omits a deleted/unlinked block from the emitted value', async () => {
+      const { prepareItemsForEmit, unlinkBlock } = await seed([baseRecord()]);
+      await unlinkBlock(10);
+      expect(prepareItemsForEmit()).toEqual([]);
+    });
+
+    it('emits integer sort values after a reorder (fix #42 guard)', async () => {
+      const { prepareItemsForEmit, reorderBlocks } = await seed([
+        baseRecord({ id: 10, sort: 0 }),
+        baseRecord({ id: 11, sort: 1, item: { id: 6, title: 'B' } })
+      ]);
+      await reorderBlocks('main', [11, 10]);
+      const out = prepareItemsForEmit() as any[];
+      for (const entry of out) {
+        expect(Number.isInteger(entry.sort)).toBe(true);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Migrates the layout-blocks interface from immediate API writes to Directus' native global Save, so users can batch multiple block changes and Save/Discard them together — consistent with standard Directus item forms.

- Block CRUD (add, link existing, duplicate, edit, status, move, reorder, unlink, delete, orphan) now mutates local state and marks blocks dirty instead of calling `api.post/patch/delete` immediately.
- `prepareItemsForEmit()` shapes the M2A field value emitted via `emit('input', …)`: bare junction id for unchanged blocks, full junction object (with `area`, `sort`, nested `item`) for dirty blocks, nested object without id for new blocks, bare item PK for linked existing items, and omission for deletes.
- The `props.value` watcher reloads read-only after an external change (Save returns persisted ids; Discard reverts to the saved value — both correct since nothing is written mid-session). An `isInternalUpdate` guard prevents emit/value feedback loops.
- Reloads reconcile **in place** (`applyLoaded`): unchanged blocks keep object identity so Vue does not re-render them.
- Temporary ids use `new_/dup_/existing_` prefixes (`BlockId = number | string`); the views compare ids as strings so drag/sort keep working for unsaved blocks (preserves fixes #40/#42).
- Exceptions kept as immediate writes (documented): `delete-everywhere` of the content item, the area-config `PATCH /fields/...` (schema, not block data), and `useAutoSetup`.

## Verification

- Type-check, build, lint (0 errors), unit tests: **43/43 green**. `useBlocks` tests rewritten to assert state mutations + 7 `prepareItemsForEmit` cases.
- **Live-verified** against the running Directus 11.11.0 instance by replaying the emitted value (`PATCH /items/<parent>` + reading the junction table): junction `area` persists, nested `item:{id,…}` deep-updates, deletion-by-omission really deletes the junction row, new-block object creates junction + item, clean blocks stay as bare ids.
- Browser-tested: Save button activates, saving works, existing drag/status/multi-area behaviour preserved.

Note: the brief field flash on *Save & Stay* is Directus core behaviour (the form refetches and re-renders all field interfaces after save — native fields flash too), tracked upstream in directus/directus#23750; not introduced by this change.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run test`
- [x] Live junction-table round-trip (area / nested update / delete / create)
- [x] Manual: add / edit / status / save / discard in the admin

Closes #29
