### PR TITLE
Token foundation: migrate legacy CSS vars to --theme--* tokens

### DIFF
--- a/src/components/AreaManager.vue
+++ b/src/components/AreaManager.vue
@@ -429,7 +429,7 @@ function save() {
 const IconPicker = {
   template: `
     <div class="icon-picker">
-      <p style="padding: 12px; color: var(--foreground-subdued);">
+      <p style="padding: 12px; color: var(--theme--foreground-subdued);">
         Icon picker not implemented
       </p>
     </div>
@@ -461,7 +461,7 @@ defineExpose({
 
   p {
     margin: 0;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
   }
 }
 
@@ -476,7 +476,7 @@ defineExpose({
 .area-section {
   h4 {
     margin: 0 0 16px;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
     font-size: 14px;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -492,9 +492,9 @@ defineExpose({
 
 .areas-table-wrapper {
   overflow-x: auto;
-  border: 1px solid var(--border-subdued);
-  border-radius: var(--border-radius);
-  background: var(--background-page);
+  border: 1px solid var(--theme--border-color-subdued);
+  border-radius: var(--theme--border-radius);
+  background: var(--theme--background);
 }
 
 .areas-table {
@@ -502,28 +502,28 @@ defineExpose({
   border-collapse: collapse;
   
   thead {
-    background: var(--background-normal-alt);
+    background: var(--theme--background-accent);
     
     th {
       padding: 12px;
       text-align: left;
       font-weight: 600;
       font-size: 12px;
-      color: var(--foreground-subdued);
+      color: var(--theme--foreground-subdued);
       text-transform: uppercase;
       letter-spacing: 0.04em;
-      border-bottom: 2px solid var(--border-normal);
+      border-bottom: 2px solid var(--theme--border-color);
     }
   }
   
   tbody {
     tr {
-      border-bottom: 1px solid var(--border-subdued);
-      background: var(--background-page);
+      border-bottom: 1px solid var(--theme--border-color-subdued);
+      background: var(--theme--background);
       transition: background-color 0.2s;
       
       &:hover {
-        background: var(--background-normal);
+        background: var(--theme--background-normal);
       }
       
       &:last-child {
@@ -567,7 +567,7 @@ defineExpose({
 
 .drag-handle {
   cursor: grab;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -578,13 +578,13 @@ defineExpose({
   }
   
   &:hover {
-    color: var(--foreground-normal);
+    color: var(--theme--foreground);
   }
 }
 
 .editable-value {
   padding: 6px 10px;
-  border-radius: var(--border-radius);
+  border-radius: var(--theme--border-radius);
   cursor: pointer;
   user-select: none;
   min-height: 32px;
@@ -593,13 +593,13 @@ defineExpose({
   transition: all 0.2s;
   
   &:not(.locked):hover {
-    background: var(--background-normal-alt);
-    box-shadow: inset 0 0 0 1px var(--border-normal);
+    background: var(--theme--background-accent);
+    box-shadow: inset 0 0 0 1px var(--theme--border-color);
   }
   
   &.locked {
     cursor: default;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
   }
 }
 
@@ -616,7 +616,7 @@ defineExpose({
   }
   
   .no-collections {
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
     font-style: italic;
     font-size: 13px;
     padding: 4px 0;
@@ -630,11 +630,11 @@ defineExpose({
 .empty-state {
   text-align: center;
   padding: 40px;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
 }
 
 .danger {
-  --v-button-background-color-hover: var(--danger-10);
-  --v-button-color-hover: var(--danger);
+  --v-button-background-color-hover: var(--theme--danger-background);
+  --v-button-color-hover: var(--theme--danger);
 }
 </style>

--- a/src/components/BlockCreator.vue
+++ b/src/components/BlockCreator.vue
@@ -565,7 +565,7 @@ watch(selectedCollection, () => {
   width: 700px;
   max-width: 90vw;
   background: white;
-  border-radius: var(--border-radius);
+  border-radius: var(--theme--border-radius);
   overflow: hidden;
 }
 
@@ -582,7 +582,7 @@ watch(selectedCollection, () => {
 
   p {
     margin: 0;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
   }
 }
 
@@ -598,7 +598,7 @@ watch(selectedCollection, () => {
     display: block;
     margin-bottom: 8px;
     font-weight: 600;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
     font-size: 14px;
   }
 }
@@ -622,33 +622,33 @@ watch(selectedCollection, () => {
   flex-direction: column;
   align-items: center;
   padding: 20px 16px;
-  background: var(--background-subdued);
-  border: 2px solid var(--border-subdued);
-  border-radius: var(--border-radius);
+  background: var(--theme--background-subdued);
+  border: 2px solid var(--theme--border-color-subdued);
+  border-radius: var(--theme--border-radius);
   cursor: pointer;
   transition: all 0.2s;
   text-align: center;
   min-height: 140px;
 
   &:hover {
-    background: var(--background-normal);
-    border-color: var(--border-normal);
+    background: var(--theme--background-normal);
+    border-color: var(--theme--border-color);
     transform: translateY(-2px);
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   }
 
   &.selected {
-    background: var(--primary-10);
-    border-color: var(--primary);
+    background: var(--theme--primary-background);
+    border-color: var(--theme--primary);
     
     .tile-icon {
-      color: var(--primary);
+      color: var(--theme--primary);
     }
   }
 
   .tile-icon {
     margin-bottom: 12px;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
     transition: color 0.2s;
   }
 
@@ -661,12 +661,12 @@ watch(selectedCollection, () => {
   .tile-title {
     font-weight: 600;
     font-size: 14px;
-    color: var(--foreground-normal);
+    color: var(--theme--foreground);
   }
 
   .tile-description {
     font-size: 12px;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
     line-height: 1.4;
   }
 }
@@ -691,7 +691,7 @@ watch(selectedCollection, () => {
     display: block;
     margin-bottom: 8px;
     font-weight: 600;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
     font-size: 14px;
   }
 
@@ -700,9 +700,9 @@ watch(selectedCollection, () => {
     align-items: center;
     gap: 12px;
     padding: 16px;
-    background: var(--background-subdued);
-    border: 1px solid var(--border-normal);
-    border-radius: var(--border-radius);
+    background: var(--theme--background-subdued);
+    border: 1px solid var(--theme--border-color);
+    border-radius: var(--theme--border-radius);
 
     .preview-content {
       flex: 1;
@@ -711,12 +711,12 @@ watch(selectedCollection, () => {
       gap: 4px;
 
       strong {
-        color: var(--foreground-normal);
+        color: var(--theme--foreground);
       }
 
       span {
         font-size: 12px;
-        color: var(--foreground-subdued);
+        color: var(--theme--foreground-subdued);
       }
     }
   }
@@ -734,15 +734,15 @@ watch(selectedCollection, () => {
   align-items: center;
   gap: 16px;
   padding: 16px;
-  background: var(--background-subdued);
-  border: 2px solid var(--border-subdued);
-  border-radius: var(--border-radius);
+  background: var(--theme--background-subdued);
+  border: 2px solid var(--theme--border-color-subdued);
+  border-radius: var(--theme--border-radius);
   cursor: pointer;
   transition: all 0.2s;
 
   &:hover {
-    background: var(--background-normal);
-    border-color: var(--border-normal);
+    background: var(--theme--background-normal);
+    border-color: var(--theme--border-color);
     transform: translateX(4px);
   }
 
@@ -752,9 +752,9 @@ watch(selectedCollection, () => {
     justify-content: center;
     width: 40px;
     height: 40px;
-    background: var(--background-normal);
+    background: var(--theme--background-normal);
     border-radius: 50%;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
   }
 
   .action-content {
@@ -766,12 +766,12 @@ watch(selectedCollection, () => {
     .action-title {
       font-weight: 600;
       font-size: 14px;
-      color: var(--foreground-normal);
+      color: var(--theme--foreground);
     }
 
     .action-description {
       font-size: 12px;
-      color: var(--foreground-subdued);
+      color: var(--theme--foreground-subdued);
     }
   }
 }
@@ -781,7 +781,7 @@ watch(selectedCollection, () => {
   justify-content: flex-end;
   gap: 12px;
   padding: 20px 24px;
-  background: var(--background-page);
-  border-top: 1px solid var(--border-subdued);
+  background: var(--theme--background);
+  border-top: 1px solid var(--theme--border-color-subdued);
 }
 </style>

--- a/src/components/BlockItem.vue
+++ b/src/components/BlockItem.vue
@@ -188,7 +188,7 @@ const canDeleteContent = computed(() => {
 // Methods
 function getBlockColor(): string {
   // You can implement custom color logic here
-  return '--foreground-normal';
+  return 'var(--theme--foreground)';
 }
 
 function handleClick() {
@@ -228,21 +228,21 @@ function updateStatus(status: string) {
   align-items: center;
   gap: 12px;
   padding: 12px;
-  background: var(--background-normal);
-  border: 1px solid var(--border-normal);
-  border-radius: var(--border-radius);
+  background: var(--theme--background-normal);
+  border: 1px solid var(--theme--border-color);
+  border-radius: var(--theme--border-radius);
   transition: all 0.2s;
   cursor: pointer;
   user-select: none;
 
   &:hover {
-    border-color: var(--border-normal-alt);
+    border-color: var(--theme--border-color-accent);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   }
 
   &.selected {
-    border-color: var(--primary);
-    background: var(--primary-alt);
+    border-color: var(--theme--primary);
+    background: var(--theme--primary-background);
   }
 
   &.draggable {
@@ -261,9 +261,10 @@ function updateStatus(status: string) {
   
   &.dragging {
     opacity: 0.5;
-    background-color: var(--primary-25);
-    border-color: var(--primary);
-    box-shadow: 0 4px 12px rgba(var(--primary-rgb), 0.2);
+    background-color: var(--theme--primary-background);
+    border-color: var(--theme--primary);
+    /* dragging glow removed: no --theme--* token for a translucent primary shadow
+       (the full dragging/drag-preview visual is redesigned in #50) */
     transform: scale(0.98);
     cursor: grabbing !important;
   }
@@ -276,8 +277,8 @@ function updateStatus(status: string) {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--background-normal-alt);
-  border-radius: var(--border-radius);
+  background: var(--theme--background-accent);
+  border-radius: var(--theme--border-radius);
 }
 
 .block-content {
@@ -286,7 +287,7 @@ function updateStatus(status: string) {
 
   .block-title {
     font-weight: 600;
-    color: var(--foreground-normal);
+    color: var(--theme--foreground);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -294,7 +295,7 @@ function updateStatus(status: string) {
 
   .block-subtitle {
     font-size: 13px;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -316,9 +317,9 @@ function updateStatus(status: string) {
 }
 
 :deep(.v-list-item.danger) {
-  --v-list-item-color: var(--danger);
-  --v-list-item-color-hover: var(--danger);
-  --v-list-item-icon-color: var(--danger);
+  --v-list-item-color: var(--theme--danger);
+  --v-list-item-color-hover: var(--theme--danger);
+  --v-list-item-icon-color: var(--theme--danger);
 }
 
 :deep(.v-list) {
@@ -332,7 +333,7 @@ function updateStatus(status: string) {
 
 .list-item-subtitle {
   font-size: 12px;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   margin-top: 2px;
 }
 </style>

--- a/src/components/DeleteConfirmationDialog.vue
+++ b/src/components/DeleteConfirmationDialog.vue
@@ -165,25 +165,25 @@ function handleCancel() {
   display: flex;
   align-items: flex-start;
   padding: 12px;
-  border: 2px solid var(--border-normal);
-  border-radius: var(--border-radius);
+  border: 2px solid var(--theme--border-color);
+  border-radius: var(--theme--border-radius);
   cursor: pointer;
   transition: all 0.2s;
-  background: var(--background-page);
+  background: var(--theme--background);
 
   &:hover {
-    border-color: var(--primary-25);
-    background: var(--background-normal);
+    border-color: var(--theme--primary-background);
+    background: var(--theme--background-normal);
   }
 
   &.selected {
-    border-color: var(--primary);
-    background: var(--primary-10);
+    border-color: var(--theme--primary);
+    background: var(--theme--primary-background);
   }
 
   &.danger.selected {
-    border-color: var(--danger);
-    background: var(--danger-10);
+    border-color: var(--theme--danger);
+    background: var(--theme--danger-background);
   }
 
   input[type="radio"] {
@@ -205,25 +205,25 @@ function handleCancel() {
 
   .v-icon {
     margin-top: 2px;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
   }
 
   .option-title {
     font-weight: 500;
     margin-bottom: 4px;
-    color: var(--foreground-normal);
+    color: var(--theme--foreground);
   }
 
   .option-description {
     font-size: 13px;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
     line-height: 1.4;
   }
 }
 
 .danger {
   .v-icon {
-    color: var(--danger);
+    color: var(--theme--danger);
   }
 }
 

--- a/src/components/EmptyState.vue
+++ b/src/components/EmptyState.vue
@@ -43,7 +43,7 @@ defineEmits<{
   justify-content: center;
   gap: 16px;
   padding: 40px;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
   text-align: center;
   min-height: 200px;
 
@@ -53,7 +53,7 @@ defineEmits<{
   }
 
   .v-icon {
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
   }
 }
 </style>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -69,7 +69,7 @@
 
           <!-- Empty State -->
           <div v-else class="area-empty">
-            <v-icon name="inbox" large color="--foreground-subdued" />
+            <v-icon name="inbox" large />
             <p>{{ area.locked ? 'Area is locked' : 'No blocks in this area' }}</p>
             <AddBlockDropdown
               v-if="!area.locked && permissions.create"
@@ -275,12 +275,12 @@ function createDragImage(block: BlockItem): HTMLElement {
     position: absolute;
     top: -1000px;
     left: -1000px;
-    background: var(--background-page);
-    border: 2px solid var(--primary);
-    border-radius: var(--border-radius);
+    background: var(--theme--background);
+    border: 2px solid var(--theme--primary);
+    border-radius: var(--theme--border-radius);
     padding: 16px;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-    font-family: var(--font-family);
+    font-family: var(--theme--fonts--sans--font-family);
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -297,7 +297,7 @@ function createDragImage(block: BlockItem): HTMLElement {
     gap: 8px;
     font-weight: 600;
     font-size: 14px;
-    color: var(--foreground-normal);
+    color: var(--theme--foreground);
   `;
   
   const icon = document.createElement('span');
@@ -314,7 +314,7 @@ function createDragImage(block: BlockItem): HTMLElement {
   const meta = document.createElement('div');
   meta.style.cssText = `
     font-size: 12px;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
   `;
   meta.textContent = getCollectionLabel(block);
   dragImage.appendChild(meta);
@@ -514,9 +514,9 @@ function handleAddBlock(areaId: string) {
 }
 
 .grid-area {
-  background: var(--background-subdued);
+  background: var(--theme--background-subdued);
   border: 1px solid black; /* Always visible subtle border */
-  border-radius: var(--border-radius);
+  border-radius: var(--theme--border-radius);
   display: flex;
   flex-direction: column;
   min-height: 200px;
@@ -527,20 +527,20 @@ function handleAddBlock(areaId: string) {
   box-sizing: border-box;
   margin-bottom: 0px; /* For wrapping */
   position: relative;
-  outline: 1px solid var(--border-subdued); /* Double border effect */
+  outline: 1px solid var(--theme--border-color-subdued); /* Double border effect */
   outline-offset: -2px;
 
   &:hover {
-    border-color: var(--border-normal);
-    background: var(--background-normal);
-    outline-color: var(--border-normal);
+    border-color: var(--theme--border-color);
+    background: var(--theme--background-normal);
+    outline-color: var(--theme--border-color);
   }
 
   &.selected {
-    border-color: var(--primary);
-    outline-color: var(--primary);
+    border-color: var(--theme--primary);
+    outline-color: var(--theme--primary);
     outline-width: 2px;
-    background: var(--primary-10);
+    background: var(--theme--primary-background);
   }
 
   &.locked {
@@ -549,10 +549,10 @@ function handleAddBlock(areaId: string) {
   }
 
   &.drag-over {
-    border-color: var(--primary);
-    outline-color: var(--primary-50);
+    border-color: var(--theme--primary);
+    outline-color: var(--theme--primary-subdued);
     outline-width: 2px;
-    background: var(--primary-alt);
+    background: var(--theme--primary-background);
   }
 
   &.empty:not(.drag-over) {
@@ -561,15 +561,15 @@ function handleAddBlock(areaId: string) {
     }
     
     .empty-state {
-      color: var(--foreground-subdued);
+      color: var(--theme--foreground-subdued);
     }
   }
 
   &.drag-not-allowed {
     cursor: not-allowed;
-    background: var(--danger-10);
-    border-color: var(--danger);
-    outline-color: var(--danger);
+    background: var(--theme--danger-background);
+    border-color: var(--theme--danger);
+    outline-color: var(--theme--danger);
     opacity: 0.7;
   }
 }
@@ -580,9 +580,9 @@ function handleAddBlock(areaId: string) {
   justify-content: space-between;
   align-items: center;
   padding: 12px 16px;
-  border-bottom: 2px solid var(--border-normal);
-  background: var(--background-normal-alt);
-  border-radius: calc(var(--border-radius) - 2px) calc(var(--border-radius) - 2px) 0 0;
+  border-bottom: 2px solid var(--theme--border-color);
+  background: var(--theme--background-accent);
+  border-radius: calc(var(--theme--border-radius) - 2px) calc(var(--theme--border-radius) - 2px) 0 0;
   min-height: 48px;
 
   .area-title {
@@ -593,10 +593,10 @@ function handleAddBlock(areaId: string) {
     font-size: 13px;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    color: var(--foreground-normal);
+    color: var(--theme--foreground);
     
     .v-icon {
-      color: var(--foreground-subdued);
+      color: var(--theme--foreground-subdued);
     }
   }
 
@@ -628,7 +628,7 @@ function handleAddBlock(areaId: string) {
   height: 100%;
   min-height: 120px;
   text-align: center;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
 
   p {
     margin: 8px 0 16px;
@@ -638,16 +638,16 @@ function handleAddBlock(areaId: string) {
 
 .area-footer {
   padding: 8px 12px;
-  border-top: 1px solid var(--border-subdued);
+  border-top: 1px solid var(--theme--border-color-subdued);
   display: flex;
   align-items: center;
   gap: 8px;
-  background: var(--background-normal);
-  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  background: var(--theme--background-normal);
+  border-radius: 0 0 var(--theme--border-radius) var(--theme--border-radius);
 
   .area-limit {
     font-size: 12px;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
   }
 }
 
@@ -707,7 +707,7 @@ body.dragging-block {
     left: 0;
     right: 0;
     bottom: 0;
-    border-bottom: 2px dashed var(--primary);
+    border-bottom: 2px dashed var(--theme--primary);
     pointer-events: none;
   }
 }

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -527,15 +527,15 @@ function createDragImage(block: BlockItem): HTMLElement {
     position: absolute;
     top: -1000px;
     left: -1000px;
-    background: var(--background-page);
-    border: 2px solid var(--primary);
-    border-radius: var(--border-radius);
+    background: var(--theme--background);
+    border: 2px solid var(--theme--primary);
+    border-radius: var(--theme--border-radius);
     padding: 12px 16px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-    font-family: var(--font-family);
+    font-family: var(--theme--fonts--sans--font-family);
     font-size: 14px;
     font-weight: 600;
-    color: var(--foreground-normal);
+    color: var(--theme--foreground);
     display: flex;
     align-items: center;
     gap: 8px;
@@ -696,7 +696,7 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
   display: flex;
   gap: 2px;
   padding: 16px 0;
-  border-bottom: 1px solid var(--border-normal);
+  border-bottom: 1px solid var(--theme--border-color);
   overflow-x: auto;
   align-items: center;
 
@@ -705,24 +705,28 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
     align-items: center;
     gap: 4px;
     padding: 8px 10px;
-    background: var(--background-normal);
-    border: 1px solid var(--border-normal);
-    border-radius: var(--border-radius);
+    background: var(--theme--background-normal);
+    border: 1px solid var(--theme--border-color);
+    border-radius: var(--theme--border-radius);
     cursor: pointer;
     white-space: nowrap;
     transition: all 0.2s;
 
     &:hover {
-      background: var(--background-normal-alt);
+      background: var(--theme--background-accent);
     }
 
+    /* FIXME(#47 -> #51): on-primary text has no --theme--* token. The white-on-primary
+       active tab (filled background + inverted text) is removed by the ListView redesign
+       (#51, segmented tabs with an underline indicator). Intentionally left on the legacy
+       --foreground-inverted until then; excluded from the #48 token-migration gate. */
     &.active {
-      background: var(--primary);
+      background: var(--theme--primary);
       color: var(--foreground-inverted);
-      border-color: var(--primary);
+      border-color: var(--theme--primary);
 
       .v-chip {
-        background: var(--primary-alt);
+        background: var(--theme--primary-background);
         color: var(--foreground-inverted);
       }
     }
@@ -733,20 +737,20 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
     
     &.orphaned {
       .v-chip.warning {
-        background: var(--warning-25);
-        color: var(--warning);
+        background: var(--theme--warning-background);
+        color: var(--theme--warning);
       }
     }
     
     &.drag-hover {
-      background: var(--primary-25);
-      border-color: var(--primary);
+      background: var(--theme--primary-background);
+      border-color: var(--theme--primary);
     }
     
     &.drag-not-allowed {
       cursor: not-allowed;
-      background: var(--danger-10);
-      border-color: var(--danger);
+      background: var(--theme--danger-background);
+      border-color: var(--theme--danger);
       opacity: 0.7;
     }
   }
@@ -773,18 +777,18 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
   .blocks-table {
     width: 100%;
     border-collapse: collapse;
-    border: 1px solid var(--border-subdued);
-    border-radius: var(--border-radius);
+    border: 1px solid var(--theme--border-color-subdued);
+    border-radius: var(--theme--border-radius);
     overflow: hidden;
     
     thead {
       position: sticky;
       top: 0;
-      background: var(--background-normal-alt);
+      background: var(--theme--background-accent);
       z-index: 1;
       
       tr {
-        border-bottom: 2px solid var(--border-normal);
+        border-bottom: 2px solid var(--theme--border-color);
       }
       
       th {
@@ -792,10 +796,10 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
         text-align: left;
         font-weight: 600;
         font-size: 12px;
-        color: var(--foreground-subdued);
+        color: var(--theme--foreground-subdued);
         text-transform: uppercase;
         letter-spacing: 0.04em;
-        border-right: 1px solid var(--border-subdued);
+        border-right: 1px solid var(--theme--border-color-subdued);
         
         &:last-child {
           border-right: none;
@@ -807,7 +811,7 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
           gap: 6px;
           
           .v-icon {
-            color: var(--foreground-subdued);
+            color: var(--theme--foreground-subdued);
           }
         }
       }
@@ -815,7 +819,7 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
     
     tbody {
       tr.block-row {
-        border-bottom: 1px solid var(--border-subdued);
+        border-bottom: 1px solid var(--theme--border-color-subdued);
         transition: background-color 0.2s;
         
         &:last-child {
@@ -824,15 +828,15 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
         
         &:hover {
           td {
-            background-color: var(--background-normal-alt);
+            background-color: var(--theme--background-accent);
           }
         }
         
         td {
           padding: 12px 16px;
           vertical-align: middle;
-          border-right: 1px solid var(--border-subdued);
-          background: var(--background-page);
+          border-right: 1px solid var(--theme--border-color-subdued);
+          background: var(--theme--background);
           
           &:last-child {
             border-right: none;
@@ -840,13 +844,13 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
           
           &.drag-cell {
             padding: 8px;
-            background: var(--background-normal);
+            background: var(--theme--background-normal);
           }
           
           &.icon-cell {
-            color: var(--foreground-subdued);
+            color: var(--theme--foreground-subdued);
             padding: 8px;
-            background: var(--background-normal);
+            background: var(--theme--background-normal);
           }
           
           &.title-cell {
@@ -869,9 +873,9 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
               font-size: 12px;
               
               &.orphaned-chip {
-                background: var(--warning-25);
-                color: var(--warning);
-                border-color: var(--warning);
+                background: var(--theme--warning-background);
+                color: var(--theme--warning);
+                border-color: var(--theme--warning);
               }
             }
           }
@@ -882,14 +886,14 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
   
   .drag-handle {
     cursor: grab;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
     display: flex;
     align-items: center;
     justify-content: center;
     padding: 4px;
     
     &:hover {
-      color: var(--foreground-normal);
+      color: var(--theme--foreground);
     }
     
     &:active {
@@ -900,7 +904,7 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
   .block-title-cell {
     .subtitle {
       font-size: 12px;
-      color: var(--foreground-subdued);
+      color: var(--theme--foreground-subdued);
       margin-top: 4px;
     }
   }
@@ -911,7 +915,7 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
       align-items: center;
       gap: 8px;
       padding: 4px 8px;
-      border-radius: var(--border-radius);
+      border-radius: var(--theme--border-radius);
       font-size: 13px;
       transition: background-color 0.2s;
       
@@ -919,7 +923,7 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
         cursor: pointer;
         
         &:hover {
-          background-color: var(--background-normal-alt);
+          background-color: var(--theme--background-accent);
         }
       }
       
@@ -927,24 +931,24 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
         width: 8px;
         height: 8px;
         border-radius: 50%;
-        background: var(--foreground-subdued);
+        background: var(--theme--foreground-subdued);
         flex-shrink: 0;
 
         &.status-published {
-          background: var(--success);
+          background: var(--theme--success);
         }
 
         &.status-draft {
-          background: var(--warning);
+          background: var(--theme--warning);
         }
         
         &.status-archived {
-          background: var(--foreground-subdued);
+          background: var(--theme--foreground-subdued);
         }
       }
       
       .status-text {
-        color: var(--foreground-normal);
+        color: var(--theme--foreground);
       }
     }
   }
@@ -955,8 +959,8 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
     justify-content: flex-end;
     
     .danger {
-      --v-button-background-color-hover: var(--danger-10);
-      --v-button-color-hover: var(--danger);
+      --v-button-background-color-hover: var(--theme--danger-background);
+      --v-button-color-hover: var(--theme--danger);
     }
   }
 }
@@ -968,7 +972,7 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
   align-items: center;
   justify-content: center;
   gap: 16px;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
 
   p {
     margin: 0;
@@ -977,14 +981,14 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
 
 .area-footer {
   padding: 16px;
-  border-top: 1px solid var(--border-subdued);
+  border-top: 1px solid var(--theme--border-color-subdued);
   display: flex;
   align-items: center;
   gap: 16px;
 
   span {
     font-size: 14px;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
   }
 }
 
@@ -993,7 +997,7 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
 }
 </style>
 
@@ -1010,18 +1014,18 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
       width: 8px;
       height: 8px;
       border-radius: 50%;
-      background: var(--foreground-subdued);
+      background: var(--theme--foreground-subdued);
 
       &.status-published {
-        background: var(--success);
+        background: var(--theme--success);
       }
 
       &.status-draft {
-        background: var(--warning);
+        background: var(--theme--warning);
       }
       
       &.status-archived {
-        background: var(--foreground-subdued);
+        background: var(--theme--foreground-subdued);
       }
     }
   }
@@ -1036,7 +1040,7 @@ body.dragging-block {
     // style. A border change revealed a hidden border width and grew the tab,
     // reflowing the content and making the blocks jump while dragging.
     &:not(.active) {
-      outline: 2px dashed var(--primary);
+      outline: 2px dashed var(--theme--primary);
       outline-offset: -2px;
     }
   }
@@ -1045,9 +1049,9 @@ body.dragging-block {
   .block-row {
     &.dragging {
       opacity: 0.5;
-      background-color: var(--primary-25) !important;
-      border-color: var(--primary) !important;
-      box-shadow: 0 2px 8px var(--primary-25);
+      background-color: var(--theme--primary-background) !important;
+      border-color: var(--theme--primary) !important;
+      box-shadow: 0 2px 8px var(--theme--primary-background);
     }
   }
 }

--- a/src/components/StatusSelector.vue
+++ b/src/components/StatusSelector.vue
@@ -62,7 +62,7 @@ defineEmits<{
   align-items: center;
   gap: 8px;
   padding: 4px 8px;
-  border-radius: var(--border-radius);
+  border-radius: var(--theme--border-radius);
   font-size: 13px;
   transition: background-color 0.2s;
   
@@ -70,7 +70,7 @@ defineEmits<{
     cursor: pointer;
     
     &:hover {
-      background-color: var(--background-normal-alt);
+      background-color: var(--theme--background-accent);
     }
   }
   
@@ -78,24 +78,24 @@ defineEmits<{
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: var(--foreground-subdued);
+    background: var(--theme--foreground-subdued);
     flex-shrink: 0;
 
     &.status-published {
-      background: var(--success);
+      background: var(--theme--success);
     }
 
     &.status-draft {
-      background: var(--warning);
+      background: var(--theme--warning);
     }
     
     &.status-archived {
-      background: var(--foreground-subdued);
+      background: var(--theme--foreground-subdued);
     }
   }
   
   .status-text {
-    color: var(--foreground-normal);
+    color: var(--theme--foreground);
   }
 }
 </style>
@@ -113,18 +113,18 @@ defineEmits<{
       width: 8px;
       height: 8px;
       border-radius: 50%;
-      background: var(--foreground-subdued);
+      background: var(--theme--foreground-subdued);
 
       &.status-published {
-        background: var(--success);
+        background: var(--theme--success);
       }
 
       &.status-draft {
-        background: var(--warning);
+        background: var(--theme--warning);
       }
       
       &.status-archived {
-        background: var(--foreground-subdued);
+        background: var(--theme--foreground-subdued);
       }
     }
   }

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -1651,7 +1651,7 @@ watch(() => props.value, () => {
   justify-content: center;
   height: 100%;
   gap: var(--spacing);
-  color: var(--foreground-subdued);
+  color: var(--theme--foreground-subdued);
 
   p {
     margin: 0;
@@ -1674,9 +1674,9 @@ watch(() => props.value, () => {
     .error-help {
       margin-top: 16px;
       text-align: left;
-      background: var(--background-subdued);
+      background: var(--theme--background-subdued);
       padding: 16px;
-      border-radius: var(--border-radius);
+      border-radius: var(--theme--border-radius);
       
       ol {
         margin: 8px 0 0 20px;
@@ -1704,7 +1704,7 @@ watch(() => props.value, () => {
     
     p {
       margin: 0;
-      color: var(--foreground-subdued);
+      color: var(--theme--foreground-subdued);
     }
   }
 }
@@ -1721,7 +1721,7 @@ watch(() => props.value, () => {
   align-items: center;
   justify-content: space-between;
   padding: 12px 0;
-  border-bottom: 1px solid var(--border-normal);
+  border-bottom: 1px solid var(--theme--border-color);
   flex-shrink: 0;
 
   .toolbar-left,
@@ -1742,10 +1742,10 @@ watch(() => props.value, () => {
     align-items: center;
     gap: 8px;
     padding: 4px 12px;
-    background: var(--background-subdued);
-    border-radius: var(--border-radius);
+    background: var(--theme--background-subdued);
+    border-radius: var(--theme--border-radius);
     font-size: 14px;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
   }
 }
 

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -1,0 +1,44 @@
+// Shared theme helpers for the Layout Blocks redesign (epic #47).
+// Token-only — every value resolves to a Directus 11 `--theme--*` token.
+// Consumed by the per-surface redesigns (#49–#55), e.g. in a component:
+//   @use '../styles/theme' as theme;
+//   .grid-area { @include theme.recessed-surface; @include theme.interactive-states; }
+// See docs/design/design_handoff_layout_blocks/{README.md §4–§7, COMPONENT_MAP.md}.
+
+// A card that sits on top of the page / a recessed area (one step "up").
+@mixin card-surface {
+  background: var(--theme--background);
+  border: var(--theme--border-width) solid var(--theme--border-color);
+  border-radius: var(--theme--border-radius);
+}
+
+// A recessed container (the area card that holds blocks).
+@mixin recessed-surface {
+  background: var(--theme--background-subdued);
+  border: var(--theme--border-width) solid var(--theme--border-color);
+  border-radius: var(--theme--border-radius);
+}
+
+// Shared hover + selected interactive states (no resting shadow).
+@mixin interactive-states {
+  &:hover {
+    border-color: var(--theme--border-color-accent);
+    background: var(--theme--background-normal);
+  }
+
+  &.selected {
+    border-color: var(--theme--primary);
+    background: var(--theme--primary-background);
+  }
+}
+
+// Drag-and-drop target highlighting.
+@mixin drop-zone-valid {
+  border: var(--theme--border-width) dashed var(--theme--primary);
+  background: var(--theme--primary-background);
+}
+
+@mixin drop-zone-invalid {
+  border: var(--theme--border-width) dashed var(--theme--danger);
+  background: var(--theme--danger-background);
+}

--- a/src/utils/blockHelpers.ts
+++ b/src/utils/blockHelpers.ts
@@ -79,12 +79,12 @@ export function createDragImage(block: BlockItem): HTMLElement {
     position: absolute;
     top: -1000px;
     left: -1000px;
-    background: var(--background-page);
-    border: 2px solid var(--primary);
-    border-radius: var(--border-radius);
+    background: var(--theme--background);
+    border: 2px solid var(--theme--primary);
+    border-radius: var(--theme--border-radius);
     padding: 16px;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-    font-family: var(--font-family);
+    font-family: var(--theme--fonts--sans--font-family);
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -101,7 +101,7 @@ export function createDragImage(block: BlockItem): HTMLElement {
     gap: 8px;
     font-weight: 600;
     font-size: 14px;
-    color: var(--foreground-normal);
+    color: var(--theme--foreground);
   `;
   
   const icon = document.createElement('span');
@@ -118,7 +118,7 @@ export function createDragImage(block: BlockItem): HTMLElement {
   const meta = document.createElement('div');
   meta.style.cssText = `
     font-size: 12px;
-    color: var(--foreground-subdued);
+    color: var(--theme--foreground-subdued);
   `;
   meta.textContent = getCollectionLabel(block.collection);
   dragImage.appendChild(meta);


### PR DESCRIPTION
## Summary

Foundation step of the #47 Layout Blocks redesign (first of #48–#57). Migrates all component styling from the legacy v10-era CSS variables to the public Directus 11 `--theme--*` token API, with **no markup or behavior changes**.

- Bulk rename of legacy vars → `--theme--*` across 9 components + `utils/blockHelpers.ts` (paren-anchored, verified — no legacy vars remain except the deferred ones below)
- New shared SCSS partial `src/styles/_theme.scss` (card/recessed surfaces, interactive + drop-zone state mixins) to be consumed by the per-surface redesigns (#49–#55)
- Nearest-standard-token mapping for non-exact legacy tints (`-25`/`-50`/`-alt` → `--theme--primary-background` / `--theme--primary-subdued`)
- Removed the `--primary-rgb` dragging glow (no `--theme--*` equivalent; the full dragging visual is redesigned in #50)
- Deferred `--foreground-inverted` active-tab text to #51 (no on-primary token; the white-on-primary tab is removed there) — kept with a `FIXME` comment, excluded from the migration gate
- Fixed a broken empty-state icon color reference in `GridView` (`color="--foreground-subdued"` string that never resolved → icon now inherits the subdued parent color)

## Accepted visual consequences (agreed "nearest-token" strategy)

A few selected/hover/drag backgrounds are slightly lighter (10% vs. 25% tint) and the dragging glow is gone. This is **not** a redesign — those surfaces get their final design in #49–#55.

## Test plan

- `npm run type-check` — passed
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run test -- --run` — 43/43 passed
- Manual: verify **light + dark** in Directus for visual parity (no intended change)

Closes #48
