### PR TITLE
Redesign BlockItem card and unify StatusSelector (status source of truth)

### DIFF
--- a/src/components/BlockItem.vue
+++ b/src/components/BlockItem.vue
@@ -224,12 +224,16 @@ function updateStatus(status: string) {
 
 <style lang="scss" scoped>
 /* Card-surface + interactive-state values are inlined here (not via the shared
-   _theme.scss mixins) on purpose: an `@include`d mixin compiles to an UN-scoped
-   global selector in this build, and `.block-item` collides with the sibling
-   `expandable-blocks` extension's own global `.block-item` rules (legacy vars,
-   some `!important`). Inlining keeps these declarations scoped (`[data-v]`) so
-   they out-specify the sibling. Token values mirror #48's card-surface /
-   interactive-states mixins. */
+   _theme.scss mixins) on purpose. In this extension's build
+   (`directus-extension build`), a rule whose declarations come from an SCSS
+   `@include` compiles to an UN-scoped global selector (verified: GridView's
+   `@include theme.recessed-surface` emits a global `.grid-area {}` in dist).
+   That is harmless for unique class names, but `.block-item` collides with the
+   sibling `expandable-blocks` extension's own global `.block-item` rules (legacy
+   vars, some `!important`) that would otherwise wipe the card border/background.
+   Inlining keeps these declarations scoped (`[data-v]`) so they out-specify the
+   sibling. Trade-off: the values duplicate #48's card-surface / interactive-
+   states mixins — keep them in sync if those tokens change. */
 .block-item {
   display: flex;
   align-items: center;

--- a/src/components/BlockItem.vue
+++ b/src/components/BlockItem.vue
@@ -223,13 +223,20 @@ function updateStatus(status: string) {
 </script>
 
 <style lang="scss" scoped>
+/* Card-surface + interactive-state values are inlined here (not via the shared
+   _theme.scss mixins) on purpose: an `@include`d mixin compiles to an UN-scoped
+   global selector in this build, and `.block-item` collides with the sibling
+   `expandable-blocks` extension's own global `.block-item` rules (legacy vars,
+   some `!important`). Inlining keeps these declarations scoped (`[data-v]`) so
+   they out-specify the sibling. Token values mirror #48's card-surface /
+   interactive-states mixins. */
 .block-item {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 12px;
-  background: var(--theme--background-normal);
-  border: 1px solid var(--theme--border-color);
+  padding: 0.75rem;
+  background: var(--theme--background);
+  border: var(--theme--border-width) solid var(--theme--border-color);
   border-radius: var(--theme--border-radius);
   transition: all 0.2s;
   cursor: pointer;
@@ -237,7 +244,7 @@ function updateStatus(status: string) {
 
   &:hover {
     border-color: var(--theme--border-color-accent);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    background: var(--theme--background-normal);
   }
 
   &.selected {
@@ -250,22 +257,23 @@ function updateStatus(status: string) {
   }
 
   &.compact {
-    padding: 8px;
+    padding: 0.5rem;
 
     .block-content {
       .block-title {
         font-size: 13px;
       }
     }
+
+    .block-icon {
+      width: 32px;
+      height: 32px;
+    }
   }
-  
+
   &.dragging {
     opacity: 0.5;
-    background-color: var(--theme--primary-background);
-    border-color: var(--theme--primary);
-    /* dragging glow removed: no --theme--* token for a translucent primary shadow
-       (the full dragging/drag-preview visual is redesigned in #50) */
-    transform: scale(0.98);
+    border-style: dashed;
     cursor: grabbing !important;
   }
 }
@@ -277,7 +285,7 @@ function updateStatus(status: string) {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: var(--theme--background-accent);
+  background: var(--theme--background-normal);
   border-radius: var(--theme--border-radius);
 }
 
@@ -286,8 +294,9 @@ function updateStatus(status: string) {
   min-width: 0;
 
   .block-title {
+    font-family: var(--theme--fonts--title--font-family);
     font-weight: 600;
-    color: var(--theme--foreground);
+    color: var(--theme--foreground-accent);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/components/StatusSelector.vue
+++ b/src/components/StatusSelector.vue
@@ -11,7 +11,7 @@
         :class="{ clickable: editable }"
         @click="editable && toggle()"
       >
-        <span class="status-dot" :class="`status-${status || 'draft'}`" />
+        <span class="lb-status-dot" :class="`status-${status || 'draft'}`" />
         <span class="status-text">{{ getStatusLabel(status) }}</span>
       </div>
     </template>
@@ -25,7 +25,7 @@
         @click="$emit('update:status', option.value)"
       >
         <v-list-item-icon>
-          <span class="status-dot" :class="`status-${option.value}`" />
+          <span class="lb-status-dot" :class="`status-${option.value}`" />
         </v-list-item-icon>
         <v-list-item-content>{{ option.text }}</v-list-item-content>
       </v-list-item>
@@ -33,7 +33,7 @@
   </v-menu>
   
   <div v-else class="status-display">
-    <span class="status-dot" :class="`status-${status || 'draft'}`" />
+    <span class="lb-status-dot" :class="`status-${status || 'draft'}`" />
     <span class="status-text">{{ getStatusLabel(status) }}</span>
   </div>
 </template>
@@ -65,35 +65,15 @@ defineEmits<{
   border-radius: var(--theme--border-radius);
   font-size: 13px;
   transition: background-color 0.2s;
-  
+
   &.clickable {
     cursor: pointer;
-    
+
     &:hover {
-      background-color: var(--theme--background-accent);
+      background-color: var(--theme--background-normal);
     }
   }
-  
-  .status-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--theme--foreground-subdued);
-    flex-shrink: 0;
 
-    &.status-published {
-      background: var(--theme--success);
-    }
-
-    &.status-draft {
-      background: var(--theme--warning);
-    }
-    
-    &.status-archived {
-      background: var(--theme--foreground-subdued);
-    }
-  }
-  
   .status-text {
     color: var(--theme--foreground);
   }
@@ -101,32 +81,38 @@ defineEmits<{
 </style>
 
 <style lang="scss">
-// Global styles for status dropdown
-.v-list {
-  .v-list-item-icon {
-    margin-right: 12px;
-    min-width: 20px;
-    display: flex;
-    align-items: center;
-    
-    .status-dot {
-      width: 8px;
-      height: 8px;
-      border-radius: 50%;
-      background: var(--theme--foreground-subdued);
+/* Single source of truth for status-dot styling (issue #50).
+   Declared globally (not scoped) on purpose: this one definition covers BOTH
+   the in-component activator dot AND the teleported v-menu list dots. Two
+   <style> blocks in an SFC cannot share a SCSS mixin, and scoped styles cannot
+   reach the teleported v-list — so a single global rule is the only way to keep
+   one source. The class is namespaced (`lb-`) so this global rule never collides
+   with the sibling `expandable-blocks` extension's own global `.status-dot`
+   rules. StatusSelector is the only place status dots are styled. */
+.lb-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--theme--foreground-subdued);
 
-      &.status-published {
-        background: var(--theme--success);
-      }
-
-      &.status-draft {
-        background: var(--theme--warning);
-      }
-      
-      &.status-archived {
-        background: var(--theme--foreground-subdued);
-      }
-    }
+  &.status-published {
+    background: var(--theme--success);
   }
+
+  &.status-draft {
+    background: var(--theme--warning);
+  }
+
+  &.status-archived {
+    background: var(--theme--foreground-subdued);
+  }
+}
+
+.v-list .v-list-item-icon {
+  margin-right: 12px;
+  min-width: 20px;
+  display: flex;
+  align-items: center;
 }
 </style>


### PR DESCRIPTION
## Summary

BlockItem + StatusSelector redesign for the #47 Layout Blocks epic. Builds on #48 (token foundation) and pairs with #49 (GridView).

- **BlockItem card** is fully tokenized: `--theme--background` + `--theme--border-color` + token radius, **no resting/hover/dragging `box-shadow`**, and the last `--primary-rgb` use is gone. Hover = `--theme--border-color-accent` + `--theme--background-normal`; selected = `--theme--primary` + `--theme--primary-background`; dragging = dashed token border + reduced opacity (no shadow/transform).
- **Icon tile** on `--theme--background-normal` (40px, 32px in compact); **title** in `--theme--foreground-accent` (title font role); compact spacing in `rem`.
- **StatusSelector is now the single source of truth** for its status dots: the duplicated scoped + global dot palettes are collapsed into **one** definition (published `--theme--success`, draft `--theme--warning`, archived `--theme--foreground-subdued`); dot **and** label kept.
- **Cross-extension robustness:** the sibling `expandable-blocks` extension ships *global* `.block-item` / `.status-dot` rules with legacy vars that are undefined in the `--theme--*` theme (invalid `var()` → `border:0 none` + transparent, some `!important`). The block-item visual rules are kept **inline-scoped** (`[data-v]`) and the dot class is **namespaced** (`.lb-status-dot`) so they out-specify / never collide with the sibling. ARIA/keyboard is intentionally deferred to **#56**.

### Scope boundary
ListView still renders its own inline `.status-dot` markup/palette. Migrating ListView to the shared `StatusSelector` (and removing its duplicated dots) is **tracked in #51**, per #50's scope note — Grid and Block already delegate to `StatusSelector`. Full light/dark theme QA is **#57**.

## Test plan

- `npm run type-check` — passed
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm run test -- --run` — 43/43 passed
- `npm run build` — passed
- **Live (Directus, Playwright)** against the 6-area demo (item 1), light theme, computed styles:
  - card `background: rgb(255,255,255)` (`--theme--background`), border `--theme--border-color`, `box-shadow: none`
  - icon tile `--theme--background-normal`; title `--theme--foreground-accent`
  - draft dot `rgb(255,164,57)` = `--theme--warning` (was grey before the sibling-collision fix); dot + label present
  - status change menu opens and shows the three namespaced dots in their token colors (success / warning / foreground-subdued); selected state works; 0 console errors
  - matches `screenshots/01-light.png`
- Dark theme: token-driven (Directus swaps `--theme--*` wholesale); full light/dark QA is tracked in **#57**.

Closes #50