### PR TITLE
Redesign DeleteConfirmationDialog with native choice control

### DIFF
--- a/src/components/BlockItem.vue
+++ b/src/components/BlockItem.vue
@@ -92,8 +92,8 @@
               <v-icon name="link_off" />
             </v-list-item-icon>
             <v-list-item-content>
-              <div>Unassign</div>
-              <div class="list-item-subtitle">Remove from this page only</div>
+              <div>Unassign from this page</div>
+              <div class="list-item-subtitle">The item stays in its collection and on other pages</div>
             </v-list-item-content>
           </v-list-item>
 
@@ -107,8 +107,8 @@
               <v-icon name="delete" />
             </v-list-item-icon>
             <v-list-item-content>
-              <div>Delete Everywhere</div>
-              <div class="list-item-subtitle">Delete item and all references</div>
+              <div>Delete everywhere</div>
+              <div class="list-item-subtitle">Permanently delete the item and all references</div>
             </v-list-item-content>
           </v-list-item>
         </v-list>

--- a/src/components/DeleteConfirmationDialog.vue
+++ b/src/components/DeleteConfirmationDialog.vue
@@ -4,7 +4,7 @@
     @update:model-value="$emit('update:modelValue', $event)"
     @esc="handleCancel"
   >
-    <v-card class="delete-confirmation">
+    <v-card>
       <v-card-title class="delete-title">
         <v-icon name="remove_circle_outline" />
         <span>Remove "{{ blockTitle }}"</span>
@@ -30,6 +30,7 @@
               :disabled="loading"
               role="radio"
               :aria-checked="!deleteContent"
+              :aria-disabled="loading"
               @click="deleteContent = false"
             >
               <v-list-item-icon>
@@ -56,7 +57,7 @@
               :disabled="loading || !canDelete"
               role="radio"
               :aria-checked="deleteContent"
-              :aria-disabled="!canDelete"
+              :aria-disabled="loading || !canDelete"
               @click="canDelete && (deleteContent = true)"
             >
               <v-list-item-icon>
@@ -153,6 +154,16 @@ watch(
   () => props.modelValue,
   (isOpen) => {
     if (isOpen) deleteContent.value = false;
+  }
+);
+
+// If the user loses delete permission while "Delete everywhere" is selected
+// (e.g. a reactive permission or item change), fall back to the safe default so
+// the dialog can never emit a delete the user is no longer allowed to perform.
+watch(
+  () => props.canDelete,
+  (allowed) => {
+    if (!allowed) deleteContent.value = false;
   }
 );
 

--- a/src/components/DeleteConfirmationDialog.vue
+++ b/src/components/DeleteConfirmationDialog.vue
@@ -4,70 +4,93 @@
     @update:model-value="$emit('update:modelValue', $event)"
     @esc="handleCancel"
   >
-    <template #activator="{ on }">
-      <slot name="activator" :on="on" />
-    </template>
-
-    <v-card>
-      <v-card-title>
-        {{ dialogTitle }}
+    <v-card class="delete-confirmation">
+      <v-card-title class="delete-title">
+        <v-icon name="remove_circle_outline" />
+        <span>Remove "{{ blockTitle }}"</span>
       </v-card-title>
 
       <v-card-text>
         <div class="delete-dialog-content">
-          <!-- Radio options for delete type -->
-          <div class="action-options">
-            <label class="action-option" :class="{ selected: deleteMode === 'unlink' }">
-              <input
-                type="radio"
-                :value="false"
-                v-model="deleteContent"
-                :disabled="loading"
-                name="delete-mode"
-              />
-              <div class="option-content">
-                <v-icon name="link_off" small />
-                <div>
-                  <div class="option-title">Remove from this page only</div>
-                  <div class="option-description">
-                    The content will remain available and can be used elsewhere
+          <!--
+            Native choice control: two selectable v-list-items (issue #53).
+            Selection/danger emphasis is applied via our OWN bound classes on the
+            v-list-item root (it inherits this component's scope id) — NOT via a
+            bare :deep(.v-list-item.active), which compiles to an UNSCOPED global
+            selector in this build and would override every active v-list-item in
+            the Directus admin (e.g. the module navigation).
+            Full radiogroup/focus-trap/focus-ring a11y is owned by #56; here we
+            only provide the static role / aria-checked / aria-disabled structure.
+          -->
+          <v-list class="choice-list">
+            <v-list-item
+              clickable
+              class="lb-choice"
+              :class="{ 'lb-choice--selected': !deleteContent }"
+              :disabled="loading"
+              role="radio"
+              :aria-checked="!deleteContent"
+              @click="deleteContent = false"
+            >
+              <v-list-item-icon>
+                <v-icon
+                  class="radio-indicator"
+                  :name="!deleteContent ? 'radio_button_checked' : 'radio_button_unchecked'"
+                />
+              </v-list-item-icon>
+              <v-list-item-content>
+                <div class="choice-body">
+                  <v-icon class="choice-type-icon" name="link_off" small />
+                  <div class="choice-text">
+                    <div class="choice-title">Unassign from this page</div>
+                    <div class="item-subtitle">The item stays in its collection and on other pages</div>
                   </div>
                 </div>
-              </div>
-            </label>
+              </v-list-item-content>
+            </v-list-item>
 
-            <label class="action-option" :class="{ selected: deleteMode === 'delete', danger: true }">
-              <input
-                type="radio"
-                :value="true"
-                v-model="deleteContent"
-                :disabled="loading || !canDelete"
-                name="delete-mode"
-              />
-              <div class="option-content">
-                <v-icon name="delete" small />
-                <div>
-                  <div class="option-title">Delete permanently</div>
-                  <div class="option-description">
-                    The content will be removed completely and cannot be recovered
+            <v-list-item
+              clickable
+              class="lb-choice"
+              :class="{ 'lb-choice--selected': deleteContent, 'lb-choice--danger': deleteContent }"
+              :disabled="loading || !canDelete"
+              role="radio"
+              :aria-checked="deleteContent"
+              :aria-disabled="!canDelete"
+              @click="canDelete && (deleteContent = true)"
+            >
+              <v-list-item-icon>
+                <v-icon
+                  class="radio-indicator"
+                  :name="deleteContent ? 'radio_button_checked' : 'radio_button_unchecked'"
+                />
+              </v-list-item-icon>
+              <v-list-item-content>
+                <div class="choice-body">
+                  <v-icon class="choice-type-icon" name="delete" small />
+                  <div class="choice-text">
+                    <div class="choice-title">Delete everywhere</div>
+                    <div class="item-subtitle">
+                      {{ canDelete ? 'Permanently delete the item and all references' : "You don't have delete permission" }}
+                    </div>
                   </div>
                 </div>
-              </div>
-            </label>
-          </div>
+              </v-list-item-content>
+            </v-list-item>
+          </v-list>
 
           <!-- Warning for permanent deletion -->
           <v-notice
-            v-if="deleteMode === 'delete'"
+            v-if="deleteContent"
             type="danger"
             class="delete-warning"
           >
-            <strong>Warning:</strong> This action cannot be undone. The content will be permanently deleted.
+            This action cannot be undone. The content will be permanently deleted.
           </v-notice>
 
-          <!-- Permission notice if can't delete -->
+          <!-- Permission notice when the user cannot delete content -->
           <v-notice
-            v-if="!canDelete && deleteMode === 'delete'"
+            v-if="!canDelete"
             type="info"
           >
             You don't have permission to delete this content. You can only remove it from this page.
@@ -78,8 +101,8 @@
       <v-card-actions>
         <v-button
           secondary
-          @click="handleCancel"
           :disabled="loading"
+          @click="handleCancel"
         >
           Cancel
         </v-button>
@@ -88,6 +111,7 @@
           :kind="deleteContent ? 'danger' : 'primary'"
           @click="handleConfirm"
         >
+          <v-icon class="cta-icon" :name="deleteContent ? 'delete' : 'link_off'" small />
           {{ confirmButtonText }}
         </v-button>
       </v-card-actions>
@@ -96,7 +120,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { logger } from '../utils/logger';
 
 interface Props {
@@ -118,19 +142,23 @@ const emit = defineEmits<{
   'cancel': [];
 }>();
 
-// Local state
+// Local state — `deleteContent` is the single source of truth for the choice and
+// is the payload of the `confirm` event (consumed in BlockItem.vue).
 const deleteContent = ref(false);
 
-// Computed properties
-const deleteMode = computed(() => deleteContent.value ? 'delete' : 'unlink');
-
-const dialogTitle = computed(() => {
-  return `Remove ${props.blockTitle}?`;
-});
+// Reset the choice whenever the dialog (re)opens, so a previous selection never
+// leaks into the next open — this also covers the backdrop-close path, which
+// closes the dialog without going through handleCancel.
+watch(
+  () => props.modelValue,
+  (isOpen) => {
+    if (isOpen) deleteContent.value = false;
+  }
+);
 
 const confirmButtonText = computed(() => {
   if (props.loading) return 'Processing...';
-  return deleteContent.value ? 'Delete Permanently' : 'Remove';
+  return deleteContent.value ? 'Delete everywhere' : 'Unassign';
 });
 
 // Methods
@@ -150,81 +178,85 @@ function handleCancel() {
 </script>
 
 <style lang="scss" scoped>
+.delete-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .delete-dialog-content {
   padding: 8px 0;
 }
 
-.action-options {
+.choice-list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
   margin-bottom: 16px;
+  padding: 0;
 }
 
-.action-option {
-  display: flex;
-  align-items: flex-start;
-  padding: 12px;
-  border: 2px solid var(--theme--border-color);
+/*
+ * Selected / danger emphasis via our own bound classes (see template comment).
+ * Fill uses the documented --v-list-item-* override vars (precedent
+ * BlockItem.vue:333) so hover keeps the tint; the 1px primary/danger border
+ * (TOKENS §7) is rendered with an inset box-shadow because v-list-item has no
+ * border. Title/subtitle text stays in --theme--foreground/-subdued (never
+ * recolored to primary/danger) to preserve dark-mode contrast (TOKENS §7).
+ */
+.lb-choice {
   border-radius: var(--theme--border-radius);
-  cursor: pointer;
-  transition: all 0.2s;
-  background: var(--theme--background);
 
-  &:hover {
-    border-color: var(--theme--primary-background);
-    background: var(--theme--background-normal);
+  &.lb-choice--selected {
+    --v-list-item-background-color: var(--theme--primary-background);
+    --v-list-item-background-color-hover: var(--theme--primary-background);
+    box-shadow: inset 0 0 0 var(--theme--border-width) var(--theme--primary);
   }
 
-  &.selected {
-    border-color: var(--theme--primary);
-    background: var(--theme--primary-background);
-  }
-
-  &.danger.selected {
-    border-color: var(--theme--danger);
-    background: var(--theme--danger-background);
-  }
-
-  input[type="radio"] {
-    margin-right: 12px;
-    margin-top: 2px;
-    cursor: pointer;
-  }
-
-  &:has(input:disabled) {
-    opacity: 0.5;
-    cursor: not-allowed;
+  &.lb-choice--danger.lb-choice--selected {
+    --v-list-item-background-color: var(--theme--danger-background);
+    --v-list-item-background-color-hover: var(--theme--danger-background);
+    box-shadow: inset 0 0 0 var(--theme--border-width) var(--theme--danger);
   }
 }
 
-.option-content {
+.radio-indicator {
+  color: var(--theme--foreground-subdued);
+}
+
+.lb-choice--selected .radio-indicator {
+  color: var(--theme--primary);
+}
+
+.lb-choice--danger.lb-choice--selected .radio-indicator {
+  color: var(--theme--danger);
+}
+
+.choice-body {
   display: flex;
   gap: 12px;
-  flex: 1;
-
-  .v-icon {
-    margin-top: 2px;
-    color: var(--theme--foreground-subdued);
-  }
-
-  .option-title {
-    font-weight: 500;
-    margin-bottom: 4px;
-    color: var(--theme--foreground);
-  }
-
-  .option-description {
-    font-size: 13px;
-    color: var(--theme--foreground-subdued);
-    line-height: 1.4;
-  }
+  align-items: flex-start;
 }
 
-.danger {
-  .v-icon {
-    color: var(--theme--danger);
-  }
+.choice-type-icon {
+  margin-top: 2px;
+  color: var(--theme--foreground-subdued);
+}
+
+.choice-title {
+  font-weight: 600;
+  color: var(--theme--foreground);
+}
+
+.item-subtitle {
+  font-size: 12px;
+  line-height: 1.4;
+  margin-top: 2px;
+  color: var(--theme--foreground-subdued);
+}
+
+.cta-icon {
+  margin-right: 4px;
 }
 
 .delete-warning {


### PR DESCRIPTION
## Summary
Redesigns the block delete confirmation (issue #53, epic #47) to use a native Directus choice control instead of custom radio markup.

- Replace `<input type="radio">` + 2px option borders with two selectable `v-list-item`s (radio glyph + type icon + title/subtitle), valid native slots only (no `v-list-item-title/-subtitle`).
- Scope-safe selected/danger emphasis via bound classes (`.lb-choice--selected/--danger`) + `--v-list-item-*` override vars + inset box-shadow border — **no** bare `:deep(.v-list-item.active)` (which ships unscoped in this build and would leak into the whole Directus admin). Verified the new selectors carry `[data-v]`.
- Header `remove_circle_outline` + `Remove "<title>"`; CTA label/icon + `kind` follow the selection.
- Permission-gated delete (`:disabled`), reachable no-permission info notice (`v-if="!canDelete"`) + subtitle hint, danger notice only on delete, loading-disable on both options, reset-on-open watcher.
- Remove dead `#activator` slot and unused computeds; align the BlockItem action-menu wording with the dialog.

## Closes
Closes #53

## Test plan
- `npm run type-check` + `npm run lint` (0 errors) + `npm run test -- --run` (48/48) — all green.
- dist scoping verified: `.lb-choice*` selectors ship with `[data-v]` (no global leak).
- Live (Playwright, light): renders per design; computed styles confirm selected fill = `--theme--primary-background`, danger fill = `--theme--danger-background`, inset primary/danger border, radio colors; danger notice only on delete; CTA switches Unassign <-> Delete everywhere; `role="radio"`/`aria-checked` present; reset-on-open works; 0 console errors.
- Dark mode is token-only (no hardcoded colors; text not recolored to primary/danger) -> correct by construction; recommend a visual dark check against `screenshots/04-dark.png` in review.

> A11y scope: only static `role`/`aria-checked`/`aria-disabled` here; radiogroup semantics, focus-trap and `:focus-visible` ring are owned by #56.