### PR TITLE
Redesign AreaManager (tokenized table, inline edit + keyboard)

### DIFF
--- a/src/components/AreaManager.vue
+++ b/src/components/AreaManager.vue
@@ -1,10 +1,5 @@
 <template>
   <div class="area-manager">
-    <div class="manager-header">
-      <h3>Manage Layout Areas</h3>
-      <p>Configure areas for your layout blocks</p>
-    </div>
-
     <div class="manager-content">
       <div class="area-section">
         <div class="section-header">
@@ -15,7 +10,7 @@
           </v-button>
         </div>
 
-        <div v-if="areas.length > 0" class="areas-table-wrapper">
+        <div v-if="localAreas.length > 0" class="areas-table-wrapper">
           <table class="areas-table">
             <thead>
               <tr>
@@ -30,7 +25,7 @@
               </tr>
             </thead>
             <draggable
-              v-model="areas"
+              v-model="localAreas"
               tag="tbody"
               item-key="id"
               handle=".drag-handle"
@@ -42,13 +37,14 @@
                     <div v-if="!area.locked" class="drag-handle">
                       <v-icon name="drag_handle" />
                     </div>
-                    <v-icon 
+                    <v-icon
                       v-else
                       name="lock"
                       small
+                      aria-label="locked"
                     />
                   </td>
-                  
+
                   <td class="icon-cell">
                     <v-menu v-if="!area.locked" show-arrow placement="bottom">
                       <template #activator="{ toggle }">
@@ -58,100 +54,155 @@
                       </template>
                       <icon-picker v-model="area.icon" />
                     </v-menu>
-                    <v-icon 
+                    <v-icon
                       v-else
                       :name="area.icon || 'dashboard_customize'"
                       small
                     />
                   </td>
-                  
+
                   <!-- Label Field -->
                   <td>
-                    <div 
-                      v-if="editingField !== `${index}-label`"
+                    <div
+                      v-if="!isEditing(index, 'label')"
                       class="editable-value"
                       :class="{ 'locked': area.locked }"
-                      @dblclick="!area.locked && startEdit(`${index}-label`, area.label)"
+                      :tabindex="area.locked ? -1 : 0"
+                      role="button"
+                      :aria-disabled="area.locked || undefined"
+                      :aria-label="area.locked ? `Label (locked): ${area.label}` : `Edit label: ${area.label || 'empty'}`"
+                      @dblclick="!area.locked && beginEdit(index, 'label', area)"
+                      @keydown="onValueKeydown($event, index, 'label', area)"
                     >
-                      {{ area.label || 'Click to edit' }}
+                      <span class="value-text value-text--label">{{ area.label || 'Click to edit' }}</span>
+                      <v-icon
+                        v-if="!area.locked"
+                        class="edit-pencil"
+                        name="edit"
+                        small
+                        @click.stop="beginEdit(index, 'label', area)"
+                      />
                     </div>
                     <v-input
                       v-else
+                      :ref="captureInput"
                       v-model="editingValue"
                       placeholder="Area Label"
                       :error="getFieldError(index, 'label')"
-                      @blur="saveEdit(area, 'label')"
-                      @keydown.enter="saveEdit(area, 'label')"
-                      @keydown.esc="cancelEdit"
                       autofocus
+                      @blur="onInputBlur(area, 'label')"
+                      @keydown.enter.stop="commitCurrentField(area)"
+                      @keydown.tab="onInputTab($event, area, index, 'label')"
+                      @keydown.esc.stop="cancelEdit"
                     />
                   </td>
-                  
+
                   <!-- ID Field -->
                   <td>
-                    <div 
-                      v-if="editingField !== `${index}-id`"
+                    <div
+                      v-if="!isEditing(index, 'id')"
                       class="editable-value"
                       :class="{ 'locked': area.locked }"
-                      @dblclick="!area.locked && startEdit(`${index}-id`, area.id)"
+                      :tabindex="area.locked ? -1 : 0"
+                      role="button"
+                      :aria-disabled="area.locked || undefined"
+                      :aria-label="area.locked ? `ID (locked): ${area.id}` : `Edit ID: ${area.id || 'empty'}`"
+                      @dblclick="!area.locked && beginEdit(index, 'id', area)"
+                      @keydown="onValueKeydown($event, index, 'id', area)"
                     >
-                      {{ area.id || 'Click to edit' }}
+                      <span class="value-text">{{ area.id || 'Click to edit' }}</span>
+                      <v-icon
+                        v-if="!area.locked"
+                        class="edit-pencil"
+                        name="edit"
+                        small
+                        @click.stop="beginEdit(index, 'id', area)"
+                      />
                     </div>
                     <v-input
                       v-else
+                      :ref="captureInput"
                       v-model="editingValue"
                       placeholder="area-id"
                       :error="getFieldError(index, 'id')"
-                      @blur="saveEdit(area, 'id', true)"
-                      @keydown.enter="saveEdit(area, 'id', true)"
-                      @keydown.esc="cancelEdit"
                       autofocus
+                      @blur="onInputBlur(area, 'id')"
+                      @keydown.enter.stop="commitCurrentField(area)"
+                      @keydown.tab="onInputTab($event, area, index, 'id')"
+                      @keydown.esc.stop="cancelEdit"
                     />
                   </td>
-                  
+
                   <!-- Width Field -->
                   <td>
-                    <div 
-                      v-if="editingField !== `${index}-width`"
+                    <div
+                      v-if="!isEditing(index, 'width')"
                       class="editable-value"
                       :class="{ 'locked': area.locked }"
-                      @dblclick="!area.locked && startEditWidth(`${index}-width`, area)"
+                      :tabindex="area.locked ? -1 : 0"
+                      role="button"
+                      :aria-disabled="area.locked || undefined"
+                      :aria-label="area.locked ? `Width (locked): ${getWidthLabel(area.width)}` : `Edit width: ${getWidthLabel(area.width)}`"
+                      @dblclick="!area.locked && beginEdit(index, 'width', area)"
+                      @keydown="onValueKeydown($event, index, 'width', area)"
                     >
-                      {{ getWidthLabel(area.width) }}
+                      <span class="value-text">{{ getWidthLabel(area.width) }}</span>
+                      <v-icon
+                        v-if="!area.locked"
+                        class="edit-pencil"
+                        name="edit"
+                        small
+                        @click.stop="beginEdit(index, 'width', area)"
+                      />
                     </div>
                     <v-select
                       v-else
                       v-model="editingValue"
-                      :items="widthOptions"
+                      :items="WIDTH_OPTIONS"
                       @update:model-value="saveEditWidth(area)"
-                      @blur="cancelEdit"
-                      @keydown.esc="cancelEdit"
+                      @blur="onWidthBlur"
+                      @keydown.tab="onInputTab($event, area, index, 'width')"
+                      @keydown.esc.stop="cancelEdit"
                     />
                   </td>
-                  
+
                   <!-- Max Items Field -->
                   <td>
-                    <div 
-                      v-if="editingField !== `${index}-maxItems`"
+                    <div
+                      v-if="!isEditing(index, 'maxItems')"
                       class="editable-value"
                       :class="{ 'locked': area.locked }"
-                      @dblclick="!area.locked && startEdit(`${index}-maxItems`, area.maxItems || '')"
+                      :tabindex="area.locked ? -1 : 0"
+                      role="button"
+                      :aria-disabled="area.locked || undefined"
+                      :aria-label="area.locked ? `Max items (locked): ${area.maxItems || 'unlimited'}` : `Edit max items: ${area.maxItems || 'unlimited'}`"
+                      @dblclick="!area.locked && beginEdit(index, 'maxItems', area)"
+                      @keydown="onValueKeydown($event, index, 'maxItems', area)"
                     >
-                      {{ area.maxItems || '∞' }}
+                      <span class="value-text">{{ area.maxItems || '∞' }}</span>
+                      <v-icon
+                        v-if="!area.locked"
+                        class="edit-pencil"
+                        name="edit"
+                        small
+                        @click.stop="beginEdit(index, 'maxItems', area)"
+                      />
                     </div>
                     <v-input
                       v-else
-                      v-model.number="editingValue"
+                      :ref="captureInput"
+                      v-model="editingValue"
                       type="number"
                       placeholder="Max"
                       :min="0"
-                      @blur="saveEdit(area, 'maxItems')"
-                      @keydown.enter="saveEdit(area, 'maxItems')"
-                      @keydown.esc="cancelEdit"
                       autofocus
+                      @blur="onInputBlur(area, 'maxItems')"
+                      @keydown.enter.stop="commitCurrentField(area)"
+                      @keydown.tab="onInputTab($event, area, index, 'maxItems')"
+                      @keydown.esc.stop="cancelEdit"
                     />
                   </td>
-                  
+
                   <!-- Allowed Collections -->
                   <td class="collections-cell">
                     <div class="collections-list">
@@ -170,14 +221,14 @@
                       <div v-else class="no-collections">
                         All collections
                       </div>
-                      <v-menu 
+                      <v-menu
                         v-if="!area.locked && getAvailableCollectionsForArea(area).length > 0"
-                        show-arrow 
+                        show-arrow
                         placement="bottom-start"
                       >
                         <template #activator="{ toggle }">
-                          <v-button 
-                            x-small 
+                          <v-button
+                            x-small
                             icon
                             @click="toggle"
                           >
@@ -197,24 +248,25 @@
                       </v-menu>
                     </div>
                   </td>
-                  
+
                   <td class="actions-cell">
                     <v-button
                       v-if="!area.locked"
+                      v-tooltip="'Remove area'"
                       icon
                       x-small
                       secondary
                       class="danger"
-                      v-tooltip="'Remove area'"
                       @click="removeArea(index)"
                     >
                       <v-icon name="delete" />
                     </v-button>
-                    <v-icon 
+                    <v-icon
                       v-else
-                      name="lock"
                       v-tooltip="'This area cannot be removed'"
+                      name="lock"
                       small
+                      aria-label="locked"
                     />
                   </td>
                 </tr>
@@ -226,22 +278,30 @@
         <div v-else class="empty-state">
           <p>No areas defined</p>
         </div>
+
+        <!--
+          Explains the locked-row treatment (lock icon + disabled inline edit).
+          Shown only when at least one area is field-configured/locked.
+        -->
+        <p v-if="hasLockedAreas" class="locked-hint">
+          <v-icon name="info" small />
+          Locked areas are defined in the field configuration and can't be edited here.
+        </p>
       </div>
     </div>
-
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, nextTick } from 'vue';
 import draggable from 'vuedraggable';
 import type { AreaConfig } from '../types';
-import { validateAreaId, validateAreaConfig, sanitizeAreaId } from '../utils/validators';
+import { WIDTH_OPTIONS } from '../utils/constants';
+import { validateAreaConfig, sanitizeAreaId } from '../utils/validators';
 
 // Props
 interface Props {
   areas: AreaConfig[];
-  defaultAreas: AreaConfig[];
   availableCollections?: Array<{ text: string; value: string }>;
 }
 
@@ -253,30 +313,46 @@ const emit = defineEmits<{
   'close': [];
 }>();
 
-// Width options
-const widthOptions = [
-  { text: 'Full (100%)', value: 100 },
-  { text: 'Half (50%)', value: 50 },
-  { text: 'Third (33%)', value: 33 },
-  { text: 'Quarter (25%)', value: 25 },
-  { text: 'Two Thirds (66%)', value: 66 },
-  { text: 'Three Quarters (75%)', value: 75 }
-];
+// Inline-edit field model (issue #54).
+// `EDITABLE_FIELDS` is the row's Tab traversal order (also the navigation set).
+// `TextEditField` is the narrower set committed via `saveEdit` (a text/number
+// `v-input`); `width` is excluded because it commits via its own `saveEditWidth`
+// path (a `v-select`). Keeping the union tight avoids a TS7053 string-index write
+// on `AreaConfig` — note `tsc` skips `.vue` scripts here, so this is review-only.
+const EDITABLE_FIELDS = ['label', 'id', 'width', 'maxItems'] as const;
+type EditableField = typeof EDITABLE_FIELDS[number];
+type TextEditField = Exclude<EditableField, 'width'>;
 
-// State
-const areas = ref<AreaConfig[]>([]);
+// State — `localAreas` is the editable working copy of the `areas` prop (renamed
+// from `areas` to avoid a prop/ref name collision that made the template binding
+// ambiguous).
+const localAreas = ref<AreaConfig[]>([]);
 const errors = ref<Record<string, string[]>>({});
-const editingField = ref<string | null>(null);
-const editingValue = ref<any>(null);
+// Index + field are tracked separately (not as a composite "i-field" string) so
+// the Tab-advance logic never has to parse a key.
+const editingArea = ref<number | null>(null);
+const editingField = ref<EditableField | null>(null);
+const editingValue = ref<string | number | null>(null);
+// Suppresses the input's @blur commit while we programmatically move the edit to
+// the next field on Tab — otherwise the trailing blur would immediately re-close
+// the freshly opened field (and double-commit the previous one).
+const isProgrammaticSwitch = ref(false);
+// Captures the currently mounted edit input (only one renders at a time) so the
+// Tab chain can focus + select its text via the DOM.
+const activeInput = ref<{ $el?: HTMLElement } | null>(null);
 
 // Initialize areas on mount
 onMounted(() => {
-  areas.value = [...props.areas];
+  localAreas.value = [...props.areas];
 });
 
 // Computed
 const hasErrors = computed(() => {
   return Object.keys(errors.value).length > 0;
+});
+
+const hasLockedAreas = computed(() => {
+  return localAreas.value.some(area => area.locked);
 });
 
 // Methods
@@ -286,29 +362,29 @@ function addArea() {
     label: 'New Area',
     icon: 'dashboard_customize'
   };
-  
-  areas.value.push(newArea);
+
+  localAreas.value.push(newArea);
   validateAreas();
 }
 
 function removeArea(index: number) {
-  areas.value.splice(index, 1);
+  localAreas.value.splice(index, 1);
   validateAreas();
 }
 
 function validateAreas() {
   const newErrors: Record<string, string[]> = {};
-  
+
   // Check for duplicate IDs
   const ids = new Set<string>();
-  
-  areas.value.forEach((area, index) => {
+
+  localAreas.value.forEach((area, index) => {
     const areaErrors = validateAreaConfig(area);
-    
+
     if (areaErrors.length > 0) {
       newErrors[`area-${index}`] = areaErrors;
     }
-    
+
     // Check for duplicate ID
     if (ids.has(area.id)) {
       if (!newErrors[`area-${index}`]) {
@@ -316,17 +392,17 @@ function validateAreas() {
       }
       newErrors[`area-${index}`].push('Duplicate area ID');
     }
-    
+
     ids.add(area.id);
   });
-  
+
   errors.value = newErrors;
 }
 
 function getFieldError(index: number, field: string): string | undefined {
   const areaErrors = errors.value[`area-${index}`];
   if (!areaErrors) return undefined;
-  
+
   // Find error related to this field
   if (field === 'id') {
     return areaErrors.find(e => e.includes('ID')) || areaErrors[0];
@@ -334,41 +410,135 @@ function getFieldError(index: number, field: string): string | undefined {
   if (field === 'label') {
     return areaErrors.find(e => e.includes('label'));
   }
-  
+
   return undefined;
 }
 
-// Inline editing functions
-function startEdit(fieldKey: string, value: any) {
-  editingField.value = fieldKey;
-  editingValue.value = value;
+// Inline editing — state helpers
+function isEditing(index: number, field: EditableField): boolean {
+  return editingArea.value === index && editingField.value === field;
 }
 
-function startEditWidth(fieldKey: string, area: AreaConfig) {
-  editingField.value = fieldKey;
-  editingValue.value = area.width || 100;
-}
-
-function saveEdit(area: AreaConfig, field: string, sanitize = false) {
-  if (field === 'id' && sanitize) {
-    area[field] = sanitizeAreaId(editingValue.value);
-  } else {
-    area[field] = editingValue.value;
+// Single entry point for entering edit mode (dblclick, pencil click, Enter/F2,
+// Tab-advance). Routes `width` to its own select-based edit path.
+function beginEdit(index: number, field: EditableField, area: AreaConfig) {
+  if (area.locked) return;
+  if (field === 'width') {
+    startEditWidth(index, area);
+    return;
   }
-  
+  const value =
+    field === 'maxItems' ? (area.maxItems ?? '') :
+    field === 'id' ? area.id :
+    area.label;
+  startEdit(index, field, value);
+}
+
+function startEdit(index: number, field: TextEditField, value: string | number | null) {
+  editingArea.value = index;
+  editingField.value = field;
+  editingValue.value = value;
+  focusActiveInput();
+}
+
+function startEditWidth(index: number, area: AreaConfig) {
+  editingArea.value = index;
+  editingField.value = 'width';
+  editingValue.value = area.width ?? 100;
+}
+
+function saveEdit(area: AreaConfig, field: TextEditField) {
+  if (field === 'id') {
+    area.id = sanitizeAreaId(String(editingValue.value ?? ''));
+  } else if (field === 'maxItems') {
+    area.maxItems =
+      editingValue.value === '' || editingValue.value == null
+        ? undefined
+        : Number(editingValue.value);
+  } else {
+    area.label = String(editingValue.value ?? '');
+  }
+
   cancelEdit();
   validateAreas();
 }
 
 function saveEditWidth(area: AreaConfig) {
-  area.width = editingValue.value;
+  area.width = typeof editingValue.value === 'number'
+    ? editingValue.value
+    : Number(editingValue.value);
   cancelEdit();
   validateAreas();
 }
 
 function cancelEdit() {
+  editingArea.value = null;
   editingField.value = null;
   editingValue.value = null;
+}
+
+// Commit whatever field is currently being edited (routes width to its own path).
+function commitCurrentField(area: AreaConfig) {
+  if (editingField.value === 'width') {
+    saveEditWidth(area);
+  } else if (editingField.value) {
+    saveEdit(area, editingField.value as TextEditField);
+  }
+}
+
+// Tab inside an input: commit + open the next editable field of the row. On the
+// last field we do nothing special — native Tab + @blur commit and move focus on.
+function onInputTab(e: KeyboardEvent, area: AreaConfig, index: number, field: EditableField) {
+  const next = EDITABLE_FIELDS[EDITABLE_FIELDS.indexOf(field) + 1];
+  if (!next) return;
+
+  e.preventDefault();
+  isProgrammaticSwitch.value = true;
+  commitCurrentField(area);
+  beginEdit(index, next, area);
+  nextTick(() => {
+    isProgrammaticSwitch.value = false;
+  });
+}
+
+function onInputBlur(area: AreaConfig, field: TextEditField) {
+  // Skip during a programmatic Tab advance, and skip when the edit was already
+  // ended (e.g. Esc → cancelEdit ran first, then the input's unmount fires a
+  // trailing blur — committing here would write the just-nulled value as empty).
+  if (isProgrammaticSwitch.value || editingArea.value === null) return;
+  saveEdit(area, field);
+}
+
+function onWidthBlur() {
+  if (isProgrammaticSwitch.value) return;
+  cancelEdit();
+}
+
+// Enter / F2 on a resting value enters edit mode (the value carries tabindex=0).
+function onValueKeydown(e: KeyboardEvent, index: number, field: EditableField, area: AreaConfig) {
+  if (area.locked) return;
+  if (e.key === 'Enter' || e.key === 'F2') {
+    e.preventDefault();
+    beginEdit(index, field, area);
+  }
+}
+
+// `autofocus` is unreliable when an input is toggled in via v-if, so we capture
+// the mounted input and focus+select it explicitly (also satisfies §4 "focus +
+// text selected"). Only the active (non-null) ref is stored.
+function captureInput(el: unknown) {
+  if (el) activeInput.value = el as { $el?: HTMLElement };
+}
+
+function focusActiveInput() {
+  nextTick(() => {
+    const root = activeInput.value?.$el;
+    const input = root?.querySelector('input');
+    if (input) {
+      input.focus();
+      input.select();
+    }
+  });
 }
 
 // Collection management
@@ -379,7 +549,7 @@ function getCollectionLabel(collection: string): string {
 
 function getAvailableCollectionsForArea(area: AreaConfig): Array<{ text: string; value: string }> {
   if (!props.availableCollections) return [];
-  
+
   const usedCollections = area.allowedTypes || [];
   return props.availableCollections.filter(c => !usedCollections.includes(c.value));
 }
@@ -394,33 +564,33 @@ function addCollection(area: AreaConfig, collection: string) {
 
 function removeCollection(area: AreaConfig, collection: string) {
   if (!area.allowedTypes) return;
-  
+
   const index = area.allowedTypes.indexOf(collection);
   if (index > -1) {
     area.allowedTypes.splice(index, 1);
   }
-  
+
   // If no collections left, remove the array
   if (area.allowedTypes.length === 0) {
     delete area.allowedTypes;
   }
-  
+
   validateAreas();
 }
 
-// Width label helper
+// Width label helper — resolves against the shared WIDTH_OPTIONS source.
 function getWidthLabel(width?: number): string {
   if (!width) return 'Full (100%)';
-  const option = widthOptions.find(w => w.value === width);
+  const option = WIDTH_OPTIONS.find(w => w.value === width);
   return option?.text || `${width}%`;
 }
 
 // Save function
 function save() {
   validateAreas();
-  
+
   if (!hasErrors.value) {
-    emit('update:areas', [...areas.value]);
+    emit('update:areas', [...localAreas.value]);
     emit('close');
   }
 }
@@ -451,20 +621,6 @@ defineExpose({
   padding: 20px;
 }
 
-.manager-header {
-  text-align: center;
-  margin-bottom: 24px;
-
-  h3 {
-    margin: 0 0 8px;
-  }
-
-  p {
-    margin: 0;
-    color: var(--theme--foreground-subdued);
-  }
-}
-
 .manager-content {
   flex: 1;
   overflow-y: auto;
@@ -478,8 +634,6 @@ defineExpose({
     margin: 0 0 16px;
     color: var(--theme--foreground-subdued);
     font-size: 14px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
   }
 
   .section-header {
@@ -492,7 +646,7 @@ defineExpose({
 
 .areas-table-wrapper {
   overflow-x: auto;
-  border: 1px solid var(--theme--border-color-subdued);
+  border: var(--theme--border-width) solid var(--theme--border-color-subdued);
   border-radius: var(--theme--border-radius);
   background: var(--theme--background);
 }
@@ -500,64 +654,63 @@ defineExpose({
 .areas-table {
   width: 100%;
   border-collapse: collapse;
-  
+
+  /* Sentence-case, subdued, hairline header (tokenized — matches ListView #51).
+     The header is not sticky here, so it carries no fill and inherits the
+     wrapper's --theme--background (screenshots/05). */
   thead {
-    background: var(--theme--background-accent);
-    
     th {
       padding: 12px;
       text-align: left;
       font-weight: 600;
       font-size: 12px;
       color: var(--theme--foreground-subdued);
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-      border-bottom: 2px solid var(--theme--border-color);
+      border-bottom: var(--theme--border-width) solid var(--theme--border-color-subdued);
     }
   }
-  
+
   tbody {
     tr {
-      border-bottom: 1px solid var(--theme--border-color-subdued);
+      border-bottom: var(--theme--border-width) solid var(--theme--border-color-subdued);
       background: var(--theme--background);
       transition: background-color 0.2s;
-      
+
       &:hover {
         background: var(--theme--background-normal);
       }
-      
+
       &:last-child {
         border-bottom: none;
       }
     }
-    
+
     td {
       padding: 8px 12px;
       vertical-align: middle;
-      
+
       &.drag-cell {
         padding: 8px;
         width: 40px;
       }
-      
+
       &.icon-cell {
         width: 60px;
         text-align: center;
       }
-      
+
       &.actions-cell {
         text-align: center;
         width: 60px;
       }
-      
+
       &.collections-cell {
         padding: 8px;
       }
-      
+
       .v-input {
         margin: 0;
       }
-      
+
       .v-select {
         margin: 0;
       }
@@ -572,35 +725,68 @@ defineExpose({
   align-items: center;
   justify-content: center;
   padding: 4px;
-  
+
   &:active {
     cursor: grabbing;
   }
-  
+
   &:hover {
     color: var(--theme--foreground);
   }
 }
 
+/* Inline-edit resting value: flat text in the cell, a hover/focus pencil
+   affordance, and a real token focus ring (replaces the former inset box-shadow
+   faux ring). The :focus-visible outline mirrors the design-handoff `.foc` rule
+   exactly so #56 can later globalize it without any visual drift. Kept inline
+   (not a mixin) because an @include in <style scoped> compiles to an UN-scoped
+   global selector in this build. */
 .editable-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   padding: 6px 10px;
   border-radius: var(--theme--border-radius);
+  border: var(--theme--border-width) solid transparent;
   cursor: pointer;
   user-select: none;
   min-height: 32px;
-  display: flex;
-  align-items: center;
-  transition: all 0.2s;
-  
+  transition: background-color 0.2s, border-color 0.2s;
+
   &:not(.locked):hover {
-    background: var(--theme--background-accent);
-    box-shadow: inset 0 0 0 1px var(--theme--border-color);
+    background: var(--theme--background);
+    border-color: var(--theme--border-color);
   }
-  
+
+  &:not(.locked):focus-visible {
+    outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+    outline-offset: 2px;
+  }
+
   &.locked {
     cursor: default;
     color: var(--theme--foreground-subdued);
   }
+}
+
+.value-text {
+  color: var(--theme--foreground);
+}
+
+.value-text--label {
+  font-weight: 600;
+  color: var(--theme--foreground-accent);
+}
+
+.edit-pencil {
+  color: var(--theme--foreground-subdued);
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+
+.editable-value:not(.locked):hover .edit-pencil,
+.editable-value:not(.locked):focus-visible .edit-pencil {
+  opacity: 1;
 }
 
 .collections-list {
@@ -608,20 +794,20 @@ defineExpose({
   flex-direction: column;
   gap: 8px;
   align-items: flex-start;
-  
+
   .collection-tags {
     display: flex;
     flex-wrap: wrap;
     gap: 4px;
   }
-  
+
   .no-collections {
     color: var(--theme--foreground-subdued);
     font-style: italic;
     font-size: 13px;
     padding: 4px 0;
   }
-  
+
   .v-button {
     margin-top: 4px;
   }
@@ -630,6 +816,15 @@ defineExpose({
 .empty-state {
   text-align: center;
   padding: 40px;
+  color: var(--theme--foreground-subdued);
+}
+
+.locked-hint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 16px 0 0;
+  font-size: 13px;
   color: var(--theme--foreground-subdued);
 }
 

--- a/src/components/AreaManager.vue
+++ b/src/components/AreaManager.vue
@@ -157,6 +157,7 @@
                     </div>
                     <v-select
                       v-else
+                      :ref="captureInput"
                       v-model="editingValue"
                       :items="WIDTH_OPTIONS"
                       @update:model-value="saveEditWidth(area)"
@@ -294,6 +295,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, nextTick } from 'vue';
+import { cloneDeep } from 'lodash-es';
 import draggable from 'vuedraggable';
 import type { AreaConfig } from '../types';
 import { WIDTH_OPTIONS } from '../utils/constants';
@@ -337,13 +339,12 @@ const editingValue = ref<string | number | null>(null);
 // the next field on Tab — otherwise the trailing blur would immediately re-close
 // the freshly opened field (and double-commit the previous one).
 const isProgrammaticSwitch = ref(false);
-// Captures the currently mounted edit input (only one renders at a time) so the
-// Tab chain can focus + select its text via the DOM.
-const activeInput = ref<{ $el?: HTMLElement } | null>(null);
-
 // Initialize areas on mount
 onMounted(() => {
-  localAreas.value = [...props.areas];
+  // Deep clone so inline edits stay isolated to the drawer until "Save Areas".
+  // A plain spread would share the area objects with the parent, leaking edits
+  // before save and making Cancel non-discarding.
+  localAreas.value = cloneDeep(props.areas);
 });
 
 // Computed
@@ -438,7 +439,6 @@ function startEdit(index: number, field: TextEditField, value: string | number |
   editingArea.value = index;
   editingField.value = field;
   editingValue.value = value;
-  focusActiveInput();
 }
 
 function startEditWidth(index: number, area: AreaConfig) {
@@ -451,10 +451,8 @@ function saveEdit(area: AreaConfig, field: TextEditField) {
   if (field === 'id') {
     area.id = sanitizeAreaId(String(editingValue.value ?? ''));
   } else if (field === 'maxItems') {
-    area.maxItems =
-      editingValue.value === '' || editingValue.value == null
-        ? undefined
-        : Number(editingValue.value);
+    const n = Number(editingValue.value);
+    area.maxItems = Number.isFinite(n) && n >= 0 ? n : undefined;
   } else {
     area.label = String(editingValue.value ?? '');
   }
@@ -523,22 +521,19 @@ function onValueKeydown(e: KeyboardEvent, index: number, field: EditableField, a
   }
 }
 
-// `autofocus` is unreliable when an input is toggled in via v-if, so we capture
-// the mounted input and focus+select it explicitly (also satisfies §4 "focus +
-// text selected"). Only the active (non-null) ref is stored.
+// Focus + select the inline edit control the moment it mounts. A function `:ref`
+// fires after the element is in the DOM, so this is deterministic — more robust
+// than a queued nextTick, where the ref-update order isn't guaranteed during a
+// Tab advance (the old input may unmount after the new one mounts). Bound on the
+// text v-inputs AND the width v-select (whose trigger is an <input>), so the Tab
+// chain keeps focus across every field. `autofocus` is unreliable on v-if toggle.
 function captureInput(el: unknown) {
-  if (el) activeInput.value = el as { $el?: HTMLElement };
-}
-
-function focusActiveInput() {
-  nextTick(() => {
-    const root = activeInput.value?.$el;
-    const input = root?.querySelector('input');
-    if (input) {
-      input.focus();
-      input.select();
-    }
-  });
+  if (!el) return;
+  const input = (el as { $el?: HTMLElement }).$el?.querySelector('input');
+  if (input) {
+    input.focus();
+    input.select();
+  }
 }
 
 // Collection management

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -102,7 +102,7 @@
         <component
           :is="viewComponent"
           v-model:blocks="blocks"
-          v-model:selectedArea="selectedArea"
+          v-model:selected-area="selectedArea"
           :areas="computedAreas"
           :options="options"
           :junction-info="junctionInfo"
@@ -225,7 +225,6 @@
           v-if="showAreaManager"
           ref="areaManagerRef"
           :areas="allConfiguredAreas"
-          :default-areas="options.areas || []"
           :available-collections="formattedAllowedCollections"
           @update:areas="handleAreasUpdate"
           @close="showAreaManager = false"
@@ -788,10 +787,13 @@ async function retrySetup() {
   await initialize();
 }
 
-// Watch for changes in allowed collections and update ItemSelector
+// Watch for changes in allowed collections and update ItemSelector.
+// `updateCollections` is NOT exposed by the shared useItemSelector composable
+// (from the expandable-blocks package), so guard the call — otherwise saving
+// areas (which recomputes allowedCollections and fires this watcher) throws
+// "updateCollections is not a function". Pre-existing; surfaced via Save Areas.
 watch(allowedCollections, (newCollections) => {
-  if (newCollections && itemSelector) {
-    // Update ItemSelector with new allowed collections
+  if (newCollections && itemSelector && typeof itemSelector.updateCollections === 'function') {
     itemSelector.updateCollections(newCollections);
   }
 }, { immediate: false });


### PR DESCRIPTION
Redesigns the AreaManager drawer to match the Directus design system (part of the #47 epic).

## Changes
- **Tokenized table:** sentence-case subdued headers (no uppercase/letter-spacing), hairline `--theme--border-color-subdued` dividers, transparent non-sticky header — consistent with ListView (#51), light **and** dark.
- **Inline edit:** discoverable pencil affordance on hover **and** `:focus-visible`; real token focus ring (`--theme--form--field--input--focus-ring-color`) replacing the inset `box-shadow` faux ring. Resting values are focusable buttons (`role`/`tabindex`/`aria-label`).
- **Keyboard (KEYBOARD_AND_A11Y §4):** `Enter`/`F2` to edit, `Enter` commit, `Tab` commit + advance to the next field (with ID sanitize preserved), `Esc` cancel + restore without closing the drawer.
- **Locked rows:** `tabindex="-1"` + `aria-disabled`, lock icons labelled, plus a "locked areas are field-configured" notice.
- **Cleanup:** reuse `WIDTH_OPTIONS` from `constants.ts` (removed a byte-identical local copy); remove the dead `defaultAreas` prop (interface.vue + AreaManager).
- **Bundled fix:** guard `itemSelector.updateCollections` (not exposed by the shared composable) — fixes a **pre-existing** crash (`updateCollections is not a function`) triggered by **Save Areas**. Also hyphenate `v-model:selected-area` (lint).

## Test plan
- `npm run type-check` ✅ · `npm run lint` (0 errors) ✅ · `npm run test -- --run` (48 passed) ✅ · build ✅
- Live (Playwright, directus.smartlabs.at, `layout_demo/1`), light **and** dark, 0 console errors:
  - Visual: headers/dividers/labels/locked rows/info notice vs `screenshots/05`
  - Inline edit: double-click · pencil-click · Enter · F2 → edit (text selected)
  - Keyboard: Tab commit+advance+sanitize · Esc cancel+restore (drawer stays open)
  - Width select, collections add/remove, add/remove area, drag reorder
  - **Save Areas**: reorder → save → no crash, order persists
  - **Validation**: duplicate ID blocks save (drawer stays open, nothing persisted)

## Notes / out of scope
- Full keyboard/ARIA hardening (focus trap, width-select keyboard, `:focus-visible` everywhere) is **#56**.
- Real icon picker + per-area collections-when-unrestricted are tracked in **#64**.

Closes #54