### PR TITLE
Redesign interface shell, toolbar, EmptyState and view-states

### DIFF
--- a/src/components/AreaManager.vue
+++ b/src/components/AreaManager.vue
@@ -2,14 +2,6 @@
   <div class="area-manager">
     <div class="manager-content">
       <div class="area-section">
-        <div class="section-header">
-          <h4>Areas</h4>
-          <v-button small @click="addArea">
-            <v-icon name="add" small left />
-            Add Area
-          </v-button>
-        </div>
-
         <div v-if="localAreas.length > 0" class="areas-table-wrapper">
           <table class="areas-table">
             <thead>
@@ -277,7 +269,8 @@
         </div>
 
         <div v-else class="empty-state">
-          <p>No areas defined</p>
+          <v-icon name="dashboard_customize" large />
+          <p>No areas defined yet — use "Add area" to create one.</p>
         </div>
 
         <!--
@@ -604,7 +597,8 @@ const IconPicker = {
 // Expose for parent
 defineExpose({
   save,
-  hasErrors
+  hasErrors,
+  addArea
 });
 </script>
 
@@ -622,21 +616,6 @@ defineExpose({
   display: flex;
   flex-direction: column;
   gap: 32px;
-}
-
-.area-section {
-  h4 {
-    margin: 0 0 16px;
-    color: var(--theme--foreground-subdued);
-    font-size: 14px;
-  }
-
-  .section-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 16px;
-  }
 }
 
 .areas-table-wrapper {

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -1,9 +1,10 @@
 <template>
-  <div class="layout-blocks-grid-view" :class="{ 'compact': options.compactMode }">
+  <div ref="rootEl" class="layout-blocks-grid-view" :class="{ 'compact': options.compactMode }">
     <div class="grid-container">
       <div
         v-for="area in visibleAreas"
         :key="area.id"
+        :data-area-id="area.id"
         class="grid-area"
         :class="{
           'selected': selectedArea === area.id,
@@ -41,8 +42,17 @@
 
         <!-- Area Content -->
         <div class="area-content">
+          <!-- Loading Skeleton (mirrors the list view's per-area loading) -->
+          <div v-if="loading" class="area-skeleton">
+            <v-skeleton-loader
+              v-for="n in SKELETON_ROWS"
+              :key="n"
+              type="block-list-item"
+            />
+          </div>
+
           <transition-group
-            v-if="getAreaBlocks(area.id).length > 0"
+            v-else-if="getAreaBlocks(area.id).length > 0"
             name="block-list"
             tag="div"
             class="blocks-container"
@@ -102,7 +112,7 @@
 
 <script setup lang="ts">
 import { logger } from '../utils/logger';
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import AddBlockDropdown from './AddBlockDropdown.vue';
 import type {
   BlockItem,
@@ -126,6 +136,30 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+
+// Number of skeleton placeholders shown per area while blocks are loading.
+const SKELETON_ROWS = 3;
+
+// Root element, used to scope the "jump to area" scroll lookup.
+const rootEl = ref<HTMLElement | null>(null);
+
+// Delay before the "jump to area" scroll. The toolbar area selector is a v-menu;
+// selecting an item closes it and returns focus to the activator, which makes the
+// browser briefly scroll the page back up. Deferring past that focus-return lets
+// the jump stick. (The sticky toolbar keeps the selector reachable, but does not
+// by itself cancel the focus-return scroll.)
+const AREA_JUMP_SCROLL_DELAY_MS = 300;
+
+// "Jump to area": when an area becomes selected, scroll its card up. block:'start'
+// + the card's scroll-margin-top land it just below the sticky toolbar.
+watch(() => props.selectedArea, (areaId) => {
+  if (!areaId) return;
+  setTimeout(() => {
+    const cards = rootEl.value?.querySelectorAll('[data-area-id]');
+    const el = cards && Array.from(cards).find(c => c.getAttribute('data-area-id') === areaId);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, AREA_JUMP_SCROLL_DELAY_MS);
+});
 
 // Emits
 const emit = defineEmits<{
@@ -471,6 +505,9 @@ function handleAddBlock(areaId: string) {
   box-sizing: border-box;
   margin-bottom: 0px; /* For wrapping */
   position: relative;
+  /* Offset the "jump to area" scroll target below both sticky bars: Directus'
+     header-bar (--header-bar-height) + our own toolbar (~78px) + a small gap. */
+  scroll-margin-top: calc(var(--header-bar-height, 61px) + 88px);
 
   &:hover {
     border-color: var(--theme--border-color-accent);
@@ -544,6 +581,13 @@ function handleAddBlock(areaId: string) {
   padding: 12px;
   overflow-y: auto;
   overflow-x: hidden;
+}
+
+.area-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px 0;
 }
 
 .blocks-container {

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -506,8 +506,9 @@ function handleAddBlock(areaId: string) {
   margin-bottom: 0px; /* For wrapping */
   position: relative;
   /* Offset the "jump to area" scroll target below both sticky bars: Directus'
-     header-bar (--header-bar-height) + our own toolbar (~78px) + a small gap. */
-  scroll-margin-top: calc(var(--header-bar-height, 61px) + 88px);
+     header-bar (--header-bar-height) + our own toolbar (--lb-toolbar-height, set
+     from its measured height in interface.vue) + a small gap. */
+  scroll-margin-top: calc(var(--header-bar-height, 61px) + var(--lb-toolbar-height, 78px) + 8px);
 
   &:hover {
     border-color: var(--theme--border-color-accent);

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -58,7 +58,7 @@
       <div ref="toolbarSentinel" class="toolbar-sentinel" aria-hidden="true"></div>
 
       <!-- Toolbar -->
-      <div class="layout-blocks-toolbar" :class="{ 'is-stuck': toolbarStuck }">
+      <div ref="toolbarEl" class="layout-blocks-toolbar" :class="{ 'is-stuck': toolbarStuck }">
         <div class="toolbar-left">
           <v-button
             v-if="options.enableAreaManagement"
@@ -75,12 +75,11 @@
           <!-- Area selector: switches the active area, driving the view's
                v-model:selected-area (ListView tabs / GridView card highlight). -->
           <v-menu v-if="computedAreas.length" show-arrow placement="bottom">
-            <template #activator="{ toggle, active }">
+            <template #activator="{ toggle }">
               <v-button
                 secondary
                 small
                 class="area-select"
-                :class="{ 'area-select--open': active }"
                 @click="toggle"
               >
                 <v-icon
@@ -521,11 +520,17 @@ const areaManagerRef = ref<any>(null);
 // stuck to the top (matching Directus' own header-bar). An IntersectionObserver
 // on a sentinel just above the toolbar flips `toolbarStuck`.
 const toolbarSentinel = ref<HTMLElement | null>(null);
+const toolbarEl = ref<HTMLElement | null>(null);
 const toolbarStuck = ref(false);
 let toolbarObserver: IntersectionObserver | null = null;
 
 watch(toolbarSentinel, (el) => {
-  if (!el || toolbarObserver) return;
+  // Re-create the observer whenever the sentinel node changes — the main
+  // interface can be re-rendered across loading/setup/error states, so we must
+  // not keep an observer bound to a detached node (the shadow would stop working).
+  toolbarObserver?.disconnect();
+  toolbarObserver = null;
+  if (!el) return;
   const headerHeight = parseInt(
     getComputedStyle(document.documentElement).getPropertyValue('--header-bar-height'),
     10,
@@ -537,9 +542,18 @@ watch(toolbarSentinel, (el) => {
   toolbarObserver.observe(el);
 });
 
+// Expose the real toolbar height as a CSS variable so the grid's "jump to area"
+// scroll-margin lands just below it without a hardcoded magic number.
+watch(toolbarEl, (el) => {
+  if (el) {
+    document.documentElement.style.setProperty('--lb-toolbar-height', `${el.offsetHeight}px`);
+  }
+});
+
 onUnmounted(() => {
   toolbarObserver?.disconnect();
   toolbarObserver = null;
+  document.documentElement.style.removeProperty('--lb-toolbar-height');
 });
 
 // Computed property for current collection fields
@@ -1824,11 +1838,11 @@ watch(() => props.value, () => {
   padding: var(--theme--form--field--input--padding, 12px) 0;
   border-bottom: var(--theme--border-width) solid var(--theme--border-color);
   flex-shrink: 0;
-  /* Sticky so the view toggle and area selector stay reachable while scrolling.
-     It also keeps the selector's v-menu activator in view, so the focus-return
-     on menu close no longer scrolls the page back to the top — letting "jump to
-     area" work with a plain scrollIntoView (no timing hack). Pinned below
-     Directus' own sticky header-bar via its --header-bar-height variable. */
+  /* Sticky so the view toggle and area selector stay reachable while scrolling,
+     and to show a subtle shadow once stuck (like Directus' own header-bar).
+     Pinned below Directus' own sticky header-bar via its --header-bar-height
+     variable. Note: sticking does NOT cancel the v-menu's focus-return scroll,
+     so the grid's "jump to area" still defers its scroll (see GridView). */
   position: sticky;
   top: var(--header-bar-height, 61px);
   z-index: 2;

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -8,8 +8,15 @@
 
     <!-- Setup State -->
     <div v-else-if="!isSetupComplete && options.autoSetup" class="layout-blocks-setup">
-      <v-progress-circular indeterminate />
-      <p>Setting up layout blocks fields...</p>
+      <v-notice type="info">
+        <div class="notice-content">
+          <v-icon name="settings" />
+          <div>
+            <strong>Setting up layout blocks…</strong>
+            <p>Preparing the M2A relationship fields. This only happens once.</p>
+          </div>
+        </div>
+      </v-notice>
     </div>
 
     <!-- Error State -->
@@ -46,14 +53,17 @@
 
     <!-- Main Interface -->
     <div v-else class="layout-blocks-container" data-testid="layout-blocks-container">
+      <!-- Sentinel above the toolbar: flips `toolbarStuck` once the toolbar
+           pins, so we can show its shadow like Directus' own header-bar. -->
+      <div ref="toolbarSentinel" class="toolbar-sentinel" aria-hidden="true"></div>
+
       <!-- Toolbar -->
-      <div class="layout-blocks-toolbar">
+      <div class="layout-blocks-toolbar" :class="{ 'is-stuck': toolbarStuck }">
         <div class="toolbar-left">
           <v-button
             v-if="options.enableAreaManagement"
             v-tooltip="'Manage areas'"
             icon
-            rounded
             secondary
             @click="showAreaManager = true"
           >
@@ -62,22 +72,66 @@
         </div>
 
         <div class="toolbar-center">
-          <div v-if="selectedArea" class="selected-area-info">
-            <v-icon 
-              v-if="selectedAreaConfig?.icon" 
-              :name="selectedAreaConfig.icon" 
-              small 
-            />
-            <span>{{ selectedAreaConfig?.label || selectedArea }}</span>
-            <v-chip small>{{ getBlocksForArea(selectedArea).length }}</v-chip>
-          </div>
+          <!-- Area selector: switches the active area, driving the view's
+               v-model:selected-area (ListView tabs / GridView card highlight). -->
+          <v-menu v-if="computedAreas.length" show-arrow placement="bottom">
+            <template #activator="{ toggle, active }">
+              <v-button
+                secondary
+                small
+                class="area-select"
+                :class="{ 'area-select--open': active }"
+                @click="toggle"
+              >
+                <v-icon
+                  v-if="selectedArea && selectedAreaConfig?.icon"
+                  :name="selectedAreaConfig.icon"
+                  small
+                  left
+                />
+                <span class="area-select__label">
+                  {{ selectedArea ? (selectedAreaConfig?.label || selectedArea) : 'All areas' }}
+                </span>
+                <v-chip v-if="selectedArea" x-small class="area-select__count">
+                  {{ getBlocksForArea(selectedArea).length }}
+                </v-chip>
+                <v-icon name="expand_more" small right />
+              </v-button>
+            </template>
+
+            <v-list>
+              <v-list-item
+                clickable
+                :active="!selectedArea"
+                @click="selectedArea = null"
+              >
+                <v-list-item-icon><v-icon name="dashboard" /></v-list-item-icon>
+                <v-list-item-content>All areas</v-list-item-content>
+              </v-list-item>
+              <v-list-item
+                v-for="area in computedAreas"
+                :key="area.id"
+                clickable
+                :active="selectedArea === area.id"
+                @click="selectedArea = area.id"
+              >
+                <v-list-item-icon>
+                  <v-icon :name="area.icon || 'crop_square'" />
+                </v-list-item-icon>
+                <v-list-item-content>{{ area.label || area.id }}</v-list-item-content>
+                <v-chip x-small>{{ getBlocksForArea(area.id).length }}</v-chip>
+                <v-icon v-if="area.locked" name="lock" x-small />
+              </v-list-item>
+            </v-list>
+          </v-menu>
         </div>
 
         <div class="toolbar-right">
           <v-button-group>
             <v-button
               v-tooltip="'Grid view'"
-              :secondary="viewMode !== 'grid'"
+              :active="viewMode === 'grid'"
+              secondary
               icon
               small
               @click="viewMode = 'grid'"
@@ -86,7 +140,8 @@
             </v-button>
             <v-button
               v-tooltip="'List view'"
-              :secondary="viewMode !== 'list'"
+              :active="viewMode === 'list'"
+              secondary
               icon
               small
               @click="viewMode = 'list'"
@@ -184,6 +239,7 @@
       <v-drawer
         v-model="drawerActive"
         :title="editingCollection ? `Edit ${getCollectionLabel(editingCollection)}` : 'Edit Block'"
+        :subtitle="editingCollection ? 'Editing in place' : undefined"
         icon="edit"
         persistent
         @cancel="handleDrawerCancel"
@@ -217,6 +273,7 @@
         v-if="options.enableAreaManagement"
         v-model="showAreaManager"
         title="Manage Areas"
+        subtitle="Define the regions blocks can be placed in"
         icon="dashboard_customize"
         persistent
         @cancel="showAreaManager = false"
@@ -231,12 +288,19 @@
         />
         
         <template #actions>
-          <v-button secondary @click="showAreaManager = false">
-            Cancel
-          </v-button>
-          <v-button @click="saveAreas">
-            Save Areas
-          </v-button>
+          <!-- Directus's v-drawer renders only the LAST child of its actions
+               slot (.action-buttons > :not(:last-child) { display: none }), so
+               wrap our buttons in one element to show both. The header's X
+               (top-left) is the native cancel/discard. -->
+          <div class="drawer-actions">
+            <v-button v-tooltip="'Add area'" secondary small @click="addAreaInManager">
+              <v-icon name="add" left />
+              Add area
+            </v-button>
+            <v-button @click="saveAreas">
+              Save Areas
+            </v-button>
+          </div>
         </template>
       </v-drawer>
     </div>
@@ -245,7 +309,7 @@
 
 <script setup lang="ts">
 import { logger } from './utils/logger';
-import { ref, computed, watch, onMounted, inject, resolveComponent, nextTick, useAttrs, getCurrentInstance } from 'vue';
+import { ref, computed, watch, onMounted, onUnmounted, inject, resolveComponent, nextTick, useAttrs, getCurrentInstance } from 'vue';
 import { useApi, useStores, useCollection } from '@directus/extensions-sdk';
 import { M2AHelper } from './utils/m2a-helper';
 import { useAutoSetup } from './composables/useAutoSetup';
@@ -452,6 +516,31 @@ const editSaving = ref(false);
 const editForm = ref<any>(null);
 const fieldOptions = ref<any>(null);
 const areaManagerRef = ref<any>(null);
+
+// Toolbar sticky-shadow: show a subtle shadow under the toolbar only once it is
+// stuck to the top (matching Directus' own header-bar). An IntersectionObserver
+// on a sentinel just above the toolbar flips `toolbarStuck`.
+const toolbarSentinel = ref<HTMLElement | null>(null);
+const toolbarStuck = ref(false);
+let toolbarObserver: IntersectionObserver | null = null;
+
+watch(toolbarSentinel, (el) => {
+  if (!el || toolbarObserver) return;
+  const headerHeight = parseInt(
+    getComputedStyle(document.documentElement).getPropertyValue('--header-bar-height'),
+    10,
+  ) || 61;
+  toolbarObserver = new IntersectionObserver(
+    ([entry]) => { toolbarStuck.value = !entry.isIntersecting; },
+    { rootMargin: `-${headerHeight + 1}px 0px 0px 0px`, threshold: 0 },
+  );
+  toolbarObserver.observe(el);
+});
+
+onUnmounted(() => {
+  toolbarObserver?.disconnect();
+  toolbarObserver = null;
+});
 
 // Computed property for current collection fields
 const editingCollectionFields = computed(() => {
@@ -1603,6 +1692,12 @@ async function handleAreasUpdate(updatedAreas: AreaConfig[]) {
 }
 
 // Save areas from area manager
+// Triggers a new area row from the area-manager drawer header (the body
+// "Add area" button moved into the drawer #actions slot in #55).
+function addAreaInManager() {
+  areaManagerRef.value?.addArea();
+}
+
 function saveAreas() {
   if (areaManagerRef.value) {
     areaManagerRef.value.save();
@@ -1645,7 +1740,6 @@ watch(() => props.value, () => {
 }
 
 .layout-blocks-loading,
-.layout-blocks-setup,
 .layout-blocks-error {
   display: flex;
   flex-direction: column;
@@ -1687,9 +1781,10 @@ watch(() => props.value, () => {
   }
 }
 
-.layout-blocks-new-item {
+.layout-blocks-new-item,
+.layout-blocks-setup {
   padding: 20px;
-  
+
   .notice-content {
     display: flex;
     align-items: flex-start;
@@ -1718,13 +1813,32 @@ watch(() => props.value, () => {
   position: relative;
 }
 
+.toolbar-sentinel {
+  height: 0;
+}
+
 .layout-blocks-toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 0;
-  border-bottom: 1px solid var(--theme--border-color);
+  padding: var(--theme--form--field--input--padding, 12px) 0;
+  border-bottom: var(--theme--border-width) solid var(--theme--border-color);
   flex-shrink: 0;
+  /* Sticky so the view toggle and area selector stay reachable while scrolling.
+     It also keeps the selector's v-menu activator in view, so the focus-return
+     on menu close no longer scrolls the page back to the top — letting "jump to
+     area" work with a plain scrollIntoView (no timing hack). Pinned below
+     Directus' own sticky header-bar via its --header-bar-height variable. */
+  position: sticky;
+  top: var(--header-bar-height, 61px);
+  z-index: 2;
+  background: var(--theme--background);
+  transition: box-shadow 0.2s;
+
+  /* Subtle elevation once stuck, matching Directus' own header-bar shadow. */
+  &.is-stuck {
+    box-shadow: var(--theme--header--box-shadow);
+  }
 
   .toolbar-left,
   .toolbar-center,
@@ -1739,15 +1853,17 @@ watch(() => props.value, () => {
     justify-content: center;
   }
 
-  .selected-area-info {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 4px 12px;
-    background: var(--theme--background-subdued);
-    border-radius: var(--theme--border-radius);
-    font-size: 14px;
-    color: var(--theme--foreground-subdued);
+  /* Area selector trigger (v-menu activator): a native v-button showing the
+     active area label + count. Switches the area context (drives the view's
+     v-model:selected-area). */
+  .area-select {
+    &__label {
+      font-weight: 600;
+    }
+
+    &__count {
+      margin-left: 6px;
+    }
   }
 }
 
@@ -1760,6 +1876,14 @@ watch(() => props.value, () => {
 .drawer-content {
   padding: 20px;
   min-height: 400px;
+}
+
+/* Wrapper so multiple drawer header actions survive Directus's
+   .action-buttons > :not(:last-child) { display: none } rule. */
+.drawer-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 </style>


### PR DESCRIPTION
## Summary
Redesign the layout-blocks shell to match the Directus design system (part of #47):

- **Toolbar**: interactive area selector (`v-menu`) with a "jump to area" scroll in grid view; view toggle expressed via the `active` prop; the toolbar is now **sticky** below the Directus header (`--header-bar-height`) and shows a **stuck-only** shadow via `--theme--header--box-shadow`; padding aligned to the form rhythm tokens.
- **View-states**: setup uses `v-notice type="info"`; GridView gains a per-area `v-skeleton-loader` while blocks load (mirrors the list view); error keeps `v-notice type="danger"` + retry.
- **EmptyState**: the shared component remains the canonical empty placeholder.
- **Drawers**: "Add area" moved from the AreaManager body into the area-manager drawer header (exposed via `defineExpose`); the edit drawer's native `v-form` is left unstyled; both drawers use native chrome with subtitles.

## Test plan
- `npm run type-check`, `npm run lint` (0 errors), `npm run test -- --run` (48 passing), build OK.
- Live (Playwright, light + dark): area selector lists all areas with icon/count/lock and drives selection; jump-to-area scrolls + highlights the card in grid; view-toggle active state; area-manager drawer subtitle + "Add area" in header adds a row; edit drawer subtitle + native v-form; new-item notice; GridView loading skeleton (5 areas x 3 rows) captured via a linked refetch; sticky toolbar + stuck-only shadow toggling on scroll.
- No DB changes: all test mutations were staged and discarded via reload.

## Notes
- A pre-existing console error (`Unexpected token '<'`) from the native rich-text (TinyMCE) language loader appears when opening the edit drawer; it is environmental and not introduced here, tracked in #66.

Closes #55