### PR TITLE
Accessibility & keyboard pass (DnD, focus, ARIA, reduced motion)

### DIFF
--- a/src/components/AddBlockDropdown.vue
+++ b/src/components/AddBlockDropdown.vue
@@ -4,9 +4,7 @@
       <template #activator="{ toggle, active }">
         <v-button
           v-tooltip="'Create new block'"
-          aria-label="Create new block"
-          aria-haspopup="menu"
-          :aria-expanded="active"
+          v-btn-aria="{ 'aria-label': 'Create new block', 'aria-haspopup': 'menu', 'aria-expanded': active }"
           icon
           :small="size === 'small'"
           :x-small="size === 'x-small'"
@@ -37,9 +35,7 @@
       <template #activator="{ toggle, active }">
         <v-button
           v-tooltip="'Link or duplicate existing'"
-          aria-label="Link or duplicate existing"
-          aria-haspopup="menu"
-          :aria-expanded="active"
+          v-btn-aria="{ 'aria-label': 'Link or duplicate existing', 'aria-haspopup': 'menu', 'aria-expanded': active }"
           icon
           :small="size === 'small'"
           :x-small="size === 'x-small'"
@@ -70,6 +66,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { vBtnAria } from '../directives/btnAria';
 import { logger } from '../utils/logger';
 import { COLLECTION_META } from '../utils/constants';
 import { getCollectionLabel, getCollectionIcon } from '../utils/blockHelpers';

--- a/src/components/AddBlockDropdown.vue
+++ b/src/components/AddBlockDropdown.vue
@@ -1,9 +1,12 @@
 <template>
   <div class="add-block-dropdown">
     <v-menu placement="bottom-start" show-arrow>
-      <template #activator="{ toggle }">
+      <template #activator="{ toggle, active }">
         <v-button
           v-tooltip="'Create new block'"
+          aria-label="Create new block"
+          aria-haspopup="menu"
+          :aria-expanded="active"
           icon
           :small="size === 'small'"
           :x-small="size === 'x-small'"
@@ -31,9 +34,12 @@
     </v-menu>
 
     <v-menu placement="bottom-start" show-arrow>
-      <template #activator="{ toggle }">
+      <template #activator="{ toggle, active }">
         <v-button
           v-tooltip="'Link or duplicate existing'"
+          aria-label="Link or duplicate existing"
+          aria-haspopup="menu"
+          :aria-expanded="active"
           icon
           :small="size === 'small'"
           :x-small="size === 'x-small'"

--- a/src/components/AreaManager.vue
+++ b/src/components/AreaManager.vue
@@ -741,7 +741,7 @@ defineExpose({
   }
 
   &:not(.locked):focus-visible {
-    outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+    outline: 2px solid var(--theme--primary);
     outline-offset: 2px;
   }
 

--- a/src/components/AreaManager.vue
+++ b/src/components/AreaManager.vue
@@ -39,8 +39,15 @@
 
                   <td class="icon-cell">
                     <v-menu v-if="!area.locked" show-arrow placement="bottom">
-                      <template #activator="{ toggle }">
-                        <v-button icon x-small @click="toggle">
+                      <template #activator="{ toggle, active }">
+                        <v-button
+                          icon
+                          x-small
+                          aria-label="Choose area icon"
+                          aria-haspopup="menu"
+                          :aria-expanded="active"
+                          @click="toggle"
+                        >
                           <v-icon :name="area.icon || 'dashboard_customize'" />
                         </v-button>
                       </template>
@@ -219,10 +226,13 @@
                         show-arrow
                         placement="bottom-start"
                       >
-                        <template #activator="{ toggle }">
+                        <template #activator="{ toggle, active }">
                           <v-button
                             x-small
                             icon
+                            aria-label="Add allowed collection"
+                            aria-haspopup="menu"
+                            :aria-expanded="active"
                             @click="toggle"
                           >
                             <v-icon name="add" />
@@ -246,6 +256,7 @@
                     <v-button
                       v-if="!area.locked"
                       v-tooltip="'Remove area'"
+                      aria-label="Remove area"
                       icon
                       x-small
                       secondary

--- a/src/components/AreaManager.vue
+++ b/src/components/AreaManager.vue
@@ -43,9 +43,7 @@
                         <v-button
                           icon
                           x-small
-                          aria-label="Choose area icon"
-                          aria-haspopup="menu"
-                          :aria-expanded="active"
+                          v-btn-aria="{ 'aria-label': 'Choose area icon', 'aria-haspopup': 'menu', 'aria-expanded': active }"
                           @click="toggle"
                         >
                           <v-icon :name="area.icon || 'dashboard_customize'" />
@@ -230,9 +228,7 @@
                           <v-button
                             x-small
                             icon
-                            aria-label="Add allowed collection"
-                            aria-haspopup="menu"
-                            :aria-expanded="active"
+                            v-btn-aria="{ 'aria-label': 'Add allowed collection', 'aria-haspopup': 'menu', 'aria-expanded': active }"
                             @click="toggle"
                           >
                             <v-icon name="add" />
@@ -256,7 +252,7 @@
                     <v-button
                       v-if="!area.locked"
                       v-tooltip="'Remove area'"
-                      aria-label="Remove area"
+                      v-btn-aria="{ 'aria-label': 'Remove area' }"
                       icon
                       x-small
                       secondary
@@ -299,6 +295,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, nextTick } from 'vue';
+import { vBtnAria } from '../directives/btnAria';
 import { cloneDeep } from 'lodash-es';
 import draggable from 'vuedraggable';
 import type { AreaConfig } from '../types';

--- a/src/components/BlockCreator.vue
+++ b/src/components/BlockCreator.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="block-creator" data-testid="block-creator-dialog">
-    <v-card-title>Add a block</v-card-title>
+    <v-card-title id="lb-block-creator-title">Add a block</v-card-title>
 
     <!-- Step progress (decorative — ARIA/keyboard is handled in the accessibility pass, #56) -->
     <div class="wizard-steps">
@@ -54,7 +54,13 @@
             :key="collection.value"
             class="block-type-tile"
             :class="{ selected: selectedCollection === collection.value }"
+            role="button"
+            tabindex="0"
+            :aria-pressed="selectedCollection === collection.value"
+            :aria-label="collection.text"
             @click="selectCollectionOption(collection.value)"
+            @keydown.enter.prevent="selectCollectionOption(collection.value)"
+            @keydown.space.prevent="selectCollectionOption(collection.value)"
           >
             <div class="tile-icon">
               <v-icon :name="getCollectionIcon(collection.value)" large />
@@ -151,7 +157,7 @@
 
 <script setup lang="ts">
 import { logger } from '../utils/logger';
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, onMounted, nextTick } from 'vue';
 import { useApi } from '@directus/extensions-sdk';
 import { useItemSelector, ItemSelectorDrawer } from 'directus-extension-expandable-blocks/shared';
 import type { AreaConfig, JunctionInfo } from '../types';
@@ -448,6 +454,17 @@ async function createNewItem() {
 watch(() => props.selectedArea, (newArea) => {
   if (newArea) localArea.value = newArea;
 });
+
+// Focus the first sensible control when the dialog opens (a11y §2). The card is
+// teleported to <body> by v-dialog, so query it there; best-effort (native
+// focus-trap keeps focus inside the dialog regardless).
+onMounted(() => {
+  nextTick(() => {
+    const root = document.querySelector('.block-creator');
+    const first = root?.querySelector<HTMLElement>('.creator-step .v-list-item, .creator-step .block-type-tile');
+    first?.focus();
+  });
+});
 </script>
 
 <style lang="scss" scoped>
@@ -546,6 +563,12 @@ watch(() => props.selectedArea, (newArea) => {
   cursor: pointer;
   transition: border-color 0.12s, background 0.12s;
 
+  /* Keyboard focus ring (a11y §1) — tiles are custom button-like elements. */
+  &:focus-visible {
+    outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+    outline-offset: 2px;
+  }
+
   .tile-icon {
     width: 46px;
     height: 46px;
@@ -580,5 +603,13 @@ watch(() => props.selectedArea, (newArea) => {
 
 .spacer {
   flex: 1;
+}
+
+/* Reduced motion (a11y §5): no tile hover/selection transitions. */
+@media (prefers-reduced-motion: reduce) {
+  .block-type-tile,
+  .block-type-tile .tile-icon {
+    transition: none;
+  }
 }
 </style>

--- a/src/components/BlockCreator.vue
+++ b/src/components/BlockCreator.vue
@@ -565,7 +565,7 @@ onMounted(() => {
 
   /* Keyboard focus ring (a11y §1) — tiles are custom button-like elements. */
   &:focus-visible {
-    outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+    outline: 2px solid var(--theme--primary);
     outline-offset: 2px;
   }
 

--- a/src/components/BlockItem.vue
+++ b/src/components/BlockItem.vue
@@ -4,7 +4,6 @@
     :class="{
       'compact': compact,
       'draggable': draggable,
-      'selected': isSelected,
       'dragging': grabbed
     }"
     :data-block-id="block.id"
@@ -154,7 +153,6 @@ interface Props {
   compact?: boolean;
   permissions: UserPermissions;
   draggable?: boolean;
-  selected?: boolean;
   /** True while this block is held in keyboard drag mode (a11y §3). */
   grabbed?: boolean;
 }
@@ -162,7 +160,6 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   compact: false,
   draggable: true,
-  selected: false,
   grabbed: false
 });
 
@@ -178,7 +175,6 @@ const emit = defineEmits<{
 }>();
 
 // State
-const isSelected = ref(props.selected);
 const showDeleteDialog = ref(false);
 const deleteLoading = ref(false);
 
@@ -201,7 +197,6 @@ function getBlockColor(): string {
 }
 
 function handleClick() {
-  isSelected.value = !isSelected.value;
   emit('click');
 }
 
@@ -260,14 +255,9 @@ function updateStatus(status: string) {
     background: var(--theme--background-normal);
   }
 
-  &.selected {
-    border-color: var(--theme--primary);
-    background: var(--theme--primary-background);
-  }
-
   /* Keyboard focus ring (a11y §1) — keyboard-only via :focus-visible. */
   &:focus-visible {
-    outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+    outline: 2px solid var(--theme--primary);
     outline-offset: 2px;
   }
 

--- a/src/components/BlockItem.vue
+++ b/src/components/BlockItem.vue
@@ -50,11 +50,10 @@
         show-arrow
         placement="bottom-end"
       >
-        <template #activator="{ toggle }">
+        <template #activator="{ toggle, active }">
           <v-button
             v-tooltip="'Options'"
-            aria-label="Block options"
-            aria-haspopup="menu"
+            v-btn-aria="{ 'aria-label': 'Block options', 'aria-haspopup': 'menu', 'aria-expanded': active }"
             icon
             x-small
             secondary
@@ -135,6 +134,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue';
+import { vBtnAria } from '../directives/btnAria';
 import type { BlockItem, AreaConfig, UserPermissions } from '../types';
 import { getBlockIcon, getBlockTitle, getBlockSubtitle, getCollectionLabel } from '../utils/blockHelpers';
 import StatusSelector from './StatusSelector.vue';

--- a/src/components/BlockItem.vue
+++ b/src/components/BlockItem.vue
@@ -4,10 +4,14 @@
     :class="{
       'compact': compact,
       'draggable': draggable,
-      'selected': isSelected
+      'selected': isSelected,
+      'dragging': grabbed
     }"
     :data-block-id="block.id"
     :draggable="draggable"
+    role="listitem"
+    tabindex="0"
+    :aria-roledescription="draggable ? 'sortable' : undefined"
     v-bind="$attrs"
     @click.stop="handleClick"
     @dblclick="handleDoubleClick"
@@ -49,6 +53,8 @@
         <template #activator="{ toggle }">
           <v-button
             v-tooltip="'Options'"
+            aria-label="Block options"
+            aria-haspopup="menu"
             icon
             x-small
             secondary
@@ -149,12 +155,15 @@ interface Props {
   permissions: UserPermissions;
   draggable?: boolean;
   selected?: boolean;
+  /** True while this block is held in keyboard drag mode (a11y §3). */
+  grabbed?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   compact: false,
   draggable: true,
-  selected: false
+  selected: false,
+  grabbed: false
 });
 
 // Emits
@@ -256,6 +265,12 @@ function updateStatus(status: string) {
     background: var(--theme--primary-background);
   }
 
+  /* Keyboard focus ring (a11y §1) — keyboard-only via :focus-visible. */
+  &:focus-visible {
+    outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+    outline-offset: 2px;
+  }
+
   &.draggable {
     cursor: move;
   }
@@ -348,5 +363,12 @@ function updateStatus(status: string) {
   font-size: 12px;
   color: var(--theme--foreground-subdued);
   margin-top: 2px;
+}
+
+/* Reduced motion (a11y §5): no card transitions when the user opts out. */
+@media (prefers-reduced-motion: reduce) {
+  .block-item {
+    transition: none;
+  }
 }
 </style>

--- a/src/components/DeleteConfirmationDialog.vue
+++ b/src/components/DeleteConfirmationDialog.vue
@@ -22,7 +22,7 @@
             Full radiogroup/focus-trap/focus-ring a11y is owned by #56; here we
             only provide the static role / aria-checked / aria-disabled structure.
           -->
-          <v-list class="choice-list">
+          <v-list class="choice-list" role="radiogroup" aria-label="How to remove this block">
             <v-list-item
               clickable
               class="lb-choice"

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -559,7 +559,7 @@ function handleAddBlock(areaId: string) {
 
   /* Keyboard focus ring (a11y §1) — keyboard-only via :focus-visible. */
   &:focus-visible {
-    outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+    outline: 2px solid var(--theme--primary);
     outline-offset: 2px;
   }
 

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -13,7 +13,12 @@
           'drag-over': dragOverArea === area.id
         }"
         :style="getAreaStyle(area)"
+        role="group"
+        :aria-label="area.label"
+        tabindex="0"
         @click="selectArea(area.id)"
+        @keydown.self.enter.prevent.stop="selectArea(area.id)"
+        @keydown.self.space.prevent.stop="selectArea(area.id)"
         @dragover="handleDragOver($event, area)"
         @drop="handleDrop($event, area)"
         @dragleave="handleDragLeave"
@@ -56,6 +61,7 @@
             name="block-list"
             tag="div"
             class="blocks-container"
+            role="list"
           >
             <block-item-component
               v-for="(block, index) in getAreaBlocks(area.id)"
@@ -66,6 +72,7 @@
               :compact="options.compactMode"
               :permissions="permissions"
               :draggable="options.enableDragDrop && (!area.locked || area.id === 'orphaned')"
+              :grabbed="isBlockGrabbed(block.id)"
               @edit="$emit('update-block', { blockId: block.id })"
               @remove="$emit('remove-block', block.id)"
               @unlink="$emit('unlink-block', block.id)"
@@ -74,6 +81,7 @@
               @update-status="handleBlockStatusUpdate(block, $event)"
               @dragstart="handleDragStart($event, block, area)"
               @dragend="handleDragEnd"
+              @keydown="handleBlockKeydown($event, block)"
             />
           </transition-group>
 
@@ -107,12 +115,14 @@
       </div>
     </div>
 
+    <!-- Visually-hidden live region: announces keyboard drag & drop steps. -->
+    <div class="lb-sr-only" role="status" aria-live="polite">{{ kbAnnouncement }}</div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { logger } from '../utils/logger';
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, nextTick } from 'vue';
 import AddBlockDropdown from './AddBlockDropdown.vue';
 import type {
   BlockItem,
@@ -122,7 +132,8 @@ import type {
   UserPermissions
 } from '../types';
 import BlockItemComponent from './BlockItem.vue';
-import { createDragImage } from '../utils/blockHelpers';
+import { createDragImage, getBlockTitle } from '../utils/blockHelpers';
+import { useKeyboardDnd } from '../composables/useKeyboardDnd';
 
 // Props
 interface Props {
@@ -191,9 +202,33 @@ const visibleAreas = computed(() => {
     return props.areas;
   }
   
-  return props.areas.filter(area => 
+  return props.areas.filter(area =>
     hasBlocks(area.id) || area.id === props.selectedArea
   );
+});
+
+// Keyboard drag & drop (KEYBOARD_AND_A11Y.md §3) — the focused block card itself
+// is the grab target (no separate handle in the grid). Reuses the very same
+// canDropInArea predicate as the pointer path so the rules stay identical.
+function focusBlock(blockId: BlockId): void {
+  nextTick(() => {
+    const el = rootEl.value?.querySelector(`[data-block-id="${CSS.escape(String(blockId))}"]`);
+    (el as HTMLElement | null)?.focus();
+  });
+}
+
+const {
+  announcement: kbAnnouncement,
+  isGrabbed: isBlockGrabbed,
+  handleBlockKeydown,
+} = useKeyboardDnd({
+  areas: visibleAreas,
+  getAreaBlocks,
+  canDrop: canDropInArea,
+  emitMove: (payload) => emit('move-block', payload),
+  enabled: () => !!props.options.enableDragDrop,
+  getTitle: (block) => getBlockTitle(block),
+  focusBlock,
 });
 
 // Methods
@@ -427,7 +462,14 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
   if (area.id === 'orphaned') {
     return false;
   }
-  
+
+  // Locked areas are not valid drop targets. ListView already enforced this;
+  // GridView's pointer handlers checked it separately, but folding it in here
+  // keeps a single source of truth that the keyboard DnD engine reuses too.
+  if (area.locked) {
+    return false;
+  }
+
   // Check max items
   if (area.maxItems) {
     const currentCount = getAreaBlocks(area.id).length;
@@ -512,6 +554,12 @@ function handleAddBlock(areaId: string) {
 
   &:hover {
     border-color: var(--theme--border-color-accent);
+  }
+
+  /* Keyboard focus ring (a11y §1) — keyboard-only via :focus-visible. */
+  &:focus-visible {
+    outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+    outline-offset: 2px;
   }
 
   &.selected {
@@ -675,5 +723,38 @@ function handleAddBlock(areaId: string) {
 
 :deep(.sortable-drag) {
   opacity: 0;
+}
+
+/* Visually-hidden live region (a11y §3): off-screen but readable by AT. */
+.lb-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Reduced motion (a11y §5): drop entrance/move/drag animations; keep function. */
+@media (prefers-reduced-motion: reduce) {
+  .grid-area {
+    transition: none;
+  }
+
+  .block-list-move,
+  .block-list-enter-active,
+  .block-list-leave-active,
+  .slide-enter-active,
+  .slide-leave-active {
+    transition: none;
+  }
+
+  .block-list-enter-from,
+  .block-list-leave-to {
+    transform: none;
+  }
 }
 </style>

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -229,6 +229,7 @@ const {
   enabled: () => !!props.options.enableDragDrop,
   getTitle: (block) => getBlockTitle(block),
   focusBlock,
+  navOrder: () => visibleAreas.value.flatMap((a) => getAreaBlocks(a.id).map((b) => b.id)),
 });
 
 // Methods

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -210,11 +210,25 @@ const visibleAreas = computed(() => {
 // Keyboard drag & drop (KEYBOARD_AND_A11Y.md §3) — the focused block card itself
 // is the grab target (no separate handle in the grid). Reuses the very same
 // canDropInArea predicate as the pointer path so the rules stay identical.
+/* Just past the .block-list leave/move transition (0.3s, see <style>). After a
+   cross-area move the LEAVING card lingers in its old area's transition-group
+   for that long and steals focus back to <body> when it is finally removed — so
+   besides the immediate attempt we re-assert focus once the transition settled. */
+const FOCUS_SETTLE_MS = 380;
+
 function focusBlock(blockId: BlockId): void {
-  nextTick(() => {
-    const el = rootEl.value?.querySelector(`[data-block-id="${CSS.escape(String(blockId))}"]`);
-    (el as HTMLElement | null)?.focus();
-  });
+  /* During the leave/enter transition there can briefly be TWO [data-block-id]
+     nodes (leaving ghost + entering card). Focus the one that is NOT leaving. */
+  const focusNonLeaving = () => {
+    const nodes = rootEl.value?.querySelectorAll(`[data-block-id="${CSS.escape(String(blockId))}"]`);
+    const el = nodes && (Array.from(nodes).find((n) =>
+      !n.classList.contains('block-list-leave-active') &&
+      !n.classList.contains('block-list-leave-to')
+    ) as HTMLElement | undefined);
+    el?.focus();
+  };
+  nextTick(focusNonLeaving);          /* fast path (within-area moves) */
+  setTimeout(focusNonLeaving, FOCUS_SETTLE_MS);  /* re-assert after the transition settles */
 }
 
 const {

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -1,15 +1,20 @@
 <template>
-  <div class="layout-blocks-list-view">
-    <!-- Area Tabs -->
-    <div class="area-tabs">
+  <div ref="rootEl" class="layout-blocks-list-view">
+    <!-- Area Tabs (radiogroup: ←/→ moves between tabs, roving tabindex) -->
+    <div class="area-tabs" role="radiogroup" aria-label="Areas">
       <!-- All Blocks Tab -->
       <button
         class="area-tab"
-        :class="{ 
+        role="radio"
+        data-tab-id="all"
+        :aria-checked="selectedArea === null"
+        :tabindex="selectedArea === null ? 0 : -1"
+        :class="{
           active: selectedArea === null,
           'has-blocks': true
         }"
         @click="selectArea(null)"
+        @keydown="handleTabKeydown($event, null)"
       >
         <v-icon name="view_list" small />
         <span>All Blocks</span>
@@ -17,19 +22,24 @@
           {{ blocks.length }}
         </v-chip>
       </button>
-      
+
       <!-- Defined Area Tabs -->
       <button
         v-for="area in visibleAreas"
         :key="area.id"
         class="area-tab"
-        :class="{ 
+        role="radio"
+        :data-tab-id="area.id"
+        :aria-checked="selectedArea === area.id"
+        :tabindex="selectedArea === area.id ? 0 : -1"
+        :class="{
           active: selectedArea === area.id,
           'has-blocks': hasBlocks(area.id),
           'orphaned': area.id === 'orphaned'
         }"
         :data-area-id="area.id"
         @click="selectArea(area.id)"
+        @keydown="handleTabKeydown($event, area.id)"
         @dragover.prevent="handleAreaDragOver"
         @drop="handleAreaDrop($event, area.id)"
         @dragleave="handleAreaDragLeave"
@@ -68,7 +78,7 @@
 
       <!-- Blocks List -->
       <div v-else-if="selectedAreaBlocks.length > 0" class="blocks-list">
-        <table class="blocks-table">
+        <table class="blocks-table" role="grid">
           <thead>
             <tr>
               <th v-if="options.enableDragDrop && (!selectedAreaConfig?.locked || selectedArea === 'orphaned')" style="width: 40px"></th>
@@ -106,13 +116,25 @@
             </tr>
           </thead>
           <tbody>
-            <tr v-for="block in selectedAreaBlocks" :key="block.id" class="block-row">
+            <tr
+              v-for="block in selectedAreaBlocks"
+              :key="block.id"
+              class="block-row"
+              :class="{ 'kb-grabbed': kbIsGrabbed(block.id) }"
+              role="row"
+            >
               <td v-if="options.enableDragDrop && (!selectedAreaConfig?.locked || selectedArea === 'orphaned')" class="drag-cell">
                 <div
                   class="drag-handle"
+                  role="button"
+                  tabindex="0"
+                  aria-roledescription="sortable"
+                  :aria-label="`Reorder ${getBlockTitle(block)}`"
+                  :data-block-id="block.id"
                   :draggable="true"
                   @dragstart="handleDragStart($event, block)"
                   @dragend="handleDragEnd"
+                  @keydown="handleBlockKeydown($event, block)"
                 >
                   <v-icon name="drag_handle" />
                 </div>
@@ -164,6 +186,7 @@
                   <v-button
                     v-if="permissions.update"
                     v-tooltip="'Edit'"
+                    aria-label="Edit block"
                     icon
                     x-small
                     secondary
@@ -171,10 +194,11 @@
                   >
                     <v-icon name="edit" />
                   </v-button>
-                  
+
                   <v-button
                     v-if="permissions.create"
                     v-tooltip="'Duplicate'"
+                    aria-label="Duplicate block"
                     icon
                     x-small
                     secondary
@@ -182,10 +206,11 @@
                   >
                     <v-icon name="content_copy" />
                   </v-button>
-                  
+
                   <v-button
                     v-if="permissions.delete"
                     v-tooltip="'Remove'"
+                    aria-label="Remove block"
                     icon
                     x-small
                     secondary
@@ -225,16 +250,20 @@
     <div v-else class="no-area-selected">
       <p>Select an area to view blocks</p>
     </div>
+
+    <!-- Visually-hidden live region: announces keyboard drag & drop steps. -->
+    <div class="lb-sr-only" role="status" aria-live="polite">{{ kbAnnouncement }}</div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { logger } from '../utils/logger';
-import { ref, computed, onMounted, watch } from 'vue';
+import { ref, computed, onMounted, watch, nextTick } from 'vue';
 import AddBlockDropdown from './AddBlockDropdown.vue';
 import StatusSelector from './StatusSelector.vue';
 import EmptyState from './EmptyState.vue';
 import { createDragImage } from '../utils/blockHelpers';
+import { useKeyboardDnd } from '../composables/useKeyboardDnd';
 import type {
   BlockItem,
   BlockId,
@@ -275,6 +304,10 @@ const emit = defineEmits<{
 
 // Local State
 const draggedBlock = ref<BlockItem | null>(null);
+
+// Root element, used to scope keyboard-focus lookups (re-focusing a row's grab
+// handle after a move re-renders the table).
+const rootEl = ref<HTMLElement | null>(null);
 
 // Number of placeholder rows shown while blocks are loading
 const SKELETON_ROWS = 5;
@@ -372,6 +405,51 @@ const collectionIcons: Record<string, string> = {
   content_hero: 'landscape',
   content_cta: 'ads_click'
 };
+
+// Keyboard drag & drop (KEYBOARD_AND_A11Y.md §3): the row's drag handle is the
+// grab target. ListView shows one area at a time, so onAreaChange follows the
+// block to keep it visible (and focusable) when it crosses to another area.
+function focusBlock(blockId: BlockId): void {
+  nextTick(() => {
+    const el = rootEl.value?.querySelector(`.drag-handle[data-block-id="${CSS.escape(String(blockId))}"]`);
+    (el as HTMLElement | null)?.focus();
+  });
+}
+
+const {
+  announcement: kbAnnouncement,
+  isGrabbed: kbIsGrabbed,
+  handleBlockKeydown,
+} = useKeyboardDnd({
+  areas: visibleAreas,
+  getAreaBlocks,
+  canDrop: canDropInArea,
+  emitMove: (payload) => emit('move-block', payload),
+  enabled: () => !!props.options.enableDragDrop,
+  getTitle: getBlockTitle,
+  focusBlock,
+  onAreaChange: (areaId) => selectArea(areaId),
+});
+
+// Area tabs form a radiogroup (a11y §2): the ordered tab ids, left → right
+// ("All Blocks" is represented by null).
+const tabOrder = computed<(string | null)[]>(() => [null, ...visibleAreas.value.map((a) => a.id)]);
+
+function handleTabKeydown(event: KeyboardEvent, currentId: string | null): void {
+  if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+  event.preventDefault();
+  const order = tabOrder.value;
+  const i = order.findIndex((id) => id === currentId);
+  if (i === -1) return;
+  const dir = event.key === 'ArrowLeft' ? -1 : 1;
+  const next = order[(i + dir + order.length) % order.length];
+  selectArea(next);
+  nextTick(() => {
+    const sel = next === null ? 'all' : CSS.escape(String(next));
+    const el = rootEl.value?.querySelector(`.area-tab[data-tab-id="${sel}"]`);
+    (el as HTMLElement | null)?.focus();
+  });
+}
 
 // Methods
 function getAreaBlocks(areaId: string): BlockItem[] {
@@ -653,6 +731,12 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
       color: var(--theme--foreground);
     }
 
+    /* Keyboard focus ring (a11y §1). */
+    &:focus-visible {
+      outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+      outline-offset: -2px;
+    }
+
     /* Segmented look: active tab = primary text + a 2px underline indicator
        (no filled background, so the legacy --foreground-inverted token is gone). */
     &.active {
@@ -827,11 +911,19 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
     align-items: center;
     justify-content: center;
     padding: 4px;
-    
+    border-radius: var(--theme--border-radius);
+
     &:hover {
       color: var(--theme--foreground);
     }
-    
+
+    /* Keyboard focus ring (a11y §1) — the handle is the keyboard grab target. */
+    &:focus-visible {
+      outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+      outline-offset: 2px;
+      color: var(--theme--foreground);
+    }
+
     &:active {
       cursor: grabbing;
     }
@@ -883,6 +975,33 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
   align-items: center;
   justify-content: center;
   color: var(--theme--foreground-subdued);
+}
+
+/* Keyboard-grabbed row highlight (a11y §3) — mirrors the pointer .dragging look.
+   Full path so it out-specifies the base `td` background. */
+.blocks-list .blocks-table tbody tr.block-row.kb-grabbed td {
+  background-color: var(--theme--primary-background);
+}
+
+/* Visually-hidden live region (a11y §3). */
+.lb-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Reduced motion (a11y §5). */
+@media (prefers-reduced-motion: reduce) {
+  .area-tab,
+  .block-row td {
+    transition: none;
+  }
 }
 </style>
 

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -410,11 +410,21 @@ const collectionIcons: Record<string, string> = {
 // Keyboard drag & drop (KEYBOARD_AND_A11Y.md §3): the row's drag handle is the
 // grab target. ListView shows one area at a time, so onAreaChange follows the
 // block to keep it visible (and focusable) when it crosses to another area.
+/* Re-assert focus after the row re-render settles (mirrors GridView). */
+const FOCUS_SETTLE_MS = 380;
+
 function focusBlock(blockId: BlockId): void {
-  nextTick(() => {
-    const el = rootEl.value?.querySelector(`.drag-handle[data-block-id="${CSS.escape(String(blockId))}"]`);
-    (el as HTMLElement | null)?.focus();
-  });
+  /* When a block crosses areas the table re-renders (ListView follows via
+     onAreaChange), so the row's grab handle may not exist on the first tick.
+     Focus immediately if present, and re-assert once the re-render settled. */
+  const tryFocus = () => {
+    const el = rootEl.value?.querySelector(
+      `.drag-handle[data-block-id="${CSS.escape(String(blockId))}"]`
+    ) as HTMLElement | null;
+    el?.focus();
+  };
+  nextTick(tryFocus);
+  setTimeout(tryFocus, FOCUS_SETTLE_MS);
 }
 
 const {

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -429,6 +429,7 @@ const {
   enabled: () => !!props.options.enableDragDrop,
   getTitle: getBlockTitle,
   focusBlock,
+  navOrder: () => selectedAreaBlocks.value.map((b) => b.id),
   onAreaChange: (areaId) => selectArea(areaId),
 });
 

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -80,34 +80,34 @@
       <div v-else-if="selectedAreaBlocks.length > 0" class="blocks-list">
         <table class="blocks-table" role="grid">
           <thead>
-            <tr>
-              <th v-if="options.enableDragDrop && (!selectedAreaConfig?.locked || selectedArea === 'orphaned')" style="width: 40px"></th>
-              <th style="width: 40px"></th>
-              <th>
+            <tr role="row">
+              <th v-if="options.enableDragDrop && (!selectedAreaConfig?.locked || selectedArea === 'orphaned')" role="columnheader" style="width: 40px"></th>
+              <th role="columnheader" style="width: 40px"></th>
+              <th role="columnheader">
                 <div class="header-with-icon">
                   <v-icon name="title" small />
                   <span>Title</span>
                 </div>
               </th>
-              <th style="width: 20%">
+              <th role="columnheader" style="width: 20%">
                 <div class="header-with-icon">
                   <v-icon name="category" small />
                   <span>Type</span>
                 </div>
               </th>
-              <th style="width: 15%">
+              <th role="columnheader" style="width: 15%">
                 <div class="header-with-icon">
                   <v-icon name="check_circle" small />
                   <span>Status</span>
                 </div>
               </th>
-              <th v-if="selectedArea === null || selectedArea === 'orphaned'" style="width: 15%">
+              <th v-if="selectedArea === null || selectedArea === 'orphaned'" role="columnheader" style="width: 15%">
                 <div class="header-with-icon">
                   <v-icon name="dashboard" small />
                   <span>Area</span>
                 </div>
               </th>
-              <th style="width: 120px; text-align: right">
+              <th role="columnheader" style="width: 120px; text-align: right">
                 <div class="header-with-icon" style="justify-content: flex-end">
                   <v-icon name="settings" small />
                   <span>Actions</span>
@@ -123,7 +123,7 @@
               :class="{ 'kb-grabbed': kbIsGrabbed(block.id) }"
               role="row"
             >
-              <td v-if="options.enableDragDrop && (!selectedAreaConfig?.locked || selectedArea === 'orphaned')" class="drag-cell">
+              <td v-if="options.enableDragDrop && (!selectedAreaConfig?.locked || selectedArea === 'orphaned')" role="gridcell" class="drag-cell">
                 <div
                   class="drag-handle"
                   role="button"
@@ -140,11 +140,11 @@
                 </div>
               </td>
               
-              <td class="icon-cell">
+              <td role="gridcell" class="icon-cell">
                 <v-icon :name="getBlockIcon(block)" />
               </td>
               
-              <td class="title-cell">
+              <td role="gridcell" class="title-cell">
                 <div class="block-title-cell">
                   <strong>{{ getBlockTitle(block) }}</strong>
                   <div v-if="getBlockSubtitle(block)" class="subtitle">
@@ -153,11 +153,11 @@
                 </div>
               </td>
               
-              <td class="type-cell">
+              <td role="gridcell" class="type-cell">
                 <v-chip small>{{ getCollectionLabel(block) }}</v-chip>
               </td>
               
-              <td class="status-cell">
+              <td role="gridcell" class="status-cell">
                 <status-selector
                   v-if="block.item"
                   :status="block.item.status"
@@ -166,7 +166,7 @@
                 />
               </td>
               
-              <td v-if="selectedArea === null || selectedArea === 'orphaned'" class="area-cell">
+              <td v-if="selectedArea === null || selectedArea === 'orphaned'" role="gridcell" class="area-cell">
                 <v-chip 
                   v-if="getAreaForBlock(block)"
                   small
@@ -181,12 +181,12 @@
                 </v-chip>
               </td>
               
-              <td class="actions-cell">
+              <td role="gridcell" class="actions-cell">
                 <div class="actions-wrapper">
                   <v-button
                     v-if="permissions.update"
                     v-tooltip="'Edit'"
-                    aria-label="Edit block"
+                    v-btn-aria="{ 'aria-label': 'Edit block' }"
                     icon
                     x-small
                     secondary
@@ -198,7 +198,7 @@
                   <v-button
                     v-if="permissions.create"
                     v-tooltip="'Duplicate'"
-                    aria-label="Duplicate block"
+                    v-btn-aria="{ 'aria-label': 'Duplicate block' }"
                     icon
                     x-small
                     secondary
@@ -210,7 +210,7 @@
                   <v-button
                     v-if="permissions.delete"
                     v-tooltip="'Remove'"
-                    aria-label="Remove block"
+                    v-btn-aria="{ 'aria-label': 'Remove block' }"
                     icon
                     x-small
                     secondary
@@ -264,6 +264,7 @@ import StatusSelector from './StatusSelector.vue';
 import EmptyState from './EmptyState.vue';
 import { createDragImage } from '../utils/blockHelpers';
 import { useKeyboardDnd } from '../composables/useKeyboardDnd';
+import { vBtnAria } from '../directives/btnAria';
 import type {
   BlockItem,
   BlockId,

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -735,7 +735,7 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
 
     /* Keyboard focus ring (a11y §1). */
     &:focus-visible {
-      outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+      outline: 2px solid var(--theme--primary);
       outline-offset: -2px;
     }
 
@@ -921,7 +921,7 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
 
     /* Keyboard focus ring (a11y §1) — the handle is the keyboard grab target. */
     &:focus-visible {
-      outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+      outline: 2px solid var(--theme--primary);
       outline-offset: 2px;
       color: var(--theme--foreground);
     }

--- a/src/components/StatusSelector.vue
+++ b/src/components/StatusSelector.vue
@@ -85,7 +85,7 @@ defineEmits<{
 
   /* Keyboard focus ring (a11y §1) — the status pill is a custom button. */
   &:focus-visible {
-    outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+    outline: 2px solid var(--theme--primary);
     outline-offset: 2px;
   }
 

--- a/src/components/StatusSelector.vue
+++ b/src/components/StatusSelector.vue
@@ -6,21 +6,30 @@
     :close-on-content-click="true"
   >
     <template #activator="{ toggle, active }">
-      <div 
+      <div
         class="status-display"
         :class="{ clickable: editable }"
+        role="button"
+        tabindex="0"
+        aria-haspopup="listbox"
+        :aria-expanded="active"
+        :aria-label="`Status: ${getStatusLabel(status)}. Activate to change.`"
         @click="editable && toggle()"
+        @keydown.enter.prevent="editable && toggle()"
+        @keydown.space.prevent="editable && toggle()"
       >
         <span class="lb-status-dot" :class="`status-${status || 'draft'}`" />
         <span class="status-text">{{ getStatusLabel(status) }}</span>
       </div>
     </template>
-    
-    <v-list>
+
+    <v-list role="listbox">
       <v-list-item
         v-for="option in STATUS_OPTIONS"
         :key="option.value"
         clickable
+        role="option"
+        :aria-selected="(status || 'draft') === option.value"
         :active="(status || 'draft') === option.value"
         @click="$emit('update:status', option.value)"
       >
@@ -72,6 +81,12 @@ defineEmits<{
     &:hover {
       background-color: var(--theme--background-normal);
     }
+  }
+
+  /* Keyboard focus ring (a11y §1) — the status pill is a custom button. */
+  &:focus-visible {
+    outline: 2px solid var(--theme--form--field--input--focus-ring-color);
+    outline-offset: 2px;
   }
 
   .status-text {

--- a/src/composables/useKeyboardDnd.ts
+++ b/src/composables/useKeyboardDnd.ts
@@ -42,6 +42,13 @@ export interface KeyboardDndDeps {
    */
   focusBlock: (blockId: BlockId) => void;
   /**
+   * Ordered ids of the currently focusable blocks, used by ↑/↓ to move the
+   * FOCUS between blocks while nothing is grabbed (navigation mode). GridView
+   * flattens all visible areas (DOM order); ListView returns the rendered rows
+   * of the selected area.
+   */
+  navOrder: () => BlockId[];
+  /**
    * Optional: let the view follow the block when it changes area (ListView shows
    * one area at a time, so it switches the selected area to keep the block
    * visible). GridView shows all areas at once and omits this.
@@ -171,6 +178,19 @@ export function useKeyboardDnd(deps: KeyboardDndDeps) {
   }
 
   /**
+   * Navigation mode (nothing grabbed): move FOCUS to the previous/next block in
+   * nav order. Stops at the ends (no wrap). Lets a keyboard user walk block to
+   * block with ↑/↓ instead of tabbing through each block and its actions button.
+   */
+  function focusAdjacent(block: BlockItem, direction: -1 | 1): void {
+    const order = deps.navOrder();
+    const i = order.findIndex((id) => id === block.id);
+    if (i === -1) return;
+    const target = order[i + direction];
+    if (target !== undefined) deps.focusBlock(target);
+  }
+
+  /**
    * Keydown handler bound to each block's grab element. The view passes the
    * block currently rendered at that element.
    */
@@ -179,10 +199,19 @@ export function useKeyboardDnd(deps: KeyboardDndDeps) {
     const key = event.key;
 
     if (grabbedId.value === null) {
+      /* Navigation mode: nothing grabbed → Enter/Space grabs, arrows move FOCUS. */
       if (key === 'Enter' || key === ' ') {
         event.preventDefault();
         event.stopPropagation();
         grab(block);
+      } else if (key === 'ArrowDown') {
+        event.preventDefault();
+        event.stopPropagation();
+        focusAdjacent(block, 1);
+      } else if (key === 'ArrowUp') {
+        event.preventDefault();
+        event.stopPropagation();
+        focusAdjacent(block, -1);
       }
       return;
     }

--- a/src/composables/useKeyboardDnd.ts
+++ b/src/composables/useKeyboardDnd.ts
@@ -1,0 +1,239 @@
+import { ref, nextTick, type Ref } from 'vue';
+import { logger } from '../utils/logger';
+import type { BlockItem, BlockId, AreaConfig } from '../types';
+
+/**
+ * Keyboard equivalent of the pointer drag & drop (KEYBOARD_AND_A11Y.md §3).
+ *
+ * View-agnostic: GridView and ListView both drive it through the same callbacks,
+ * so the move rules (locked / maxItems / allowedTypes / never-orphaned) live in
+ * one place and stay identical to the mouse path (each view passes its own
+ * `canDrop`, which is the very same function the pointer handlers use).
+ *
+ * Interaction model (the focused block IS the grab target — no separate handle):
+ *  - Enter / Space  → grab / drop toggle
+ *  - ArrowUp/Down   → reorder within the current area
+ *  - ArrowLeft/Right→ move to the previous/next eligible area (skips locked &
+ *                     incompatible areas)
+ *  - Escape         → cancel and restore the original position
+ *  - Tab            → suppressed while grabbed (movement is arrows-only)
+ *
+ * Every step is announced through a visually-hidden `aria-live="polite"` region
+ * (the returned `announcement` ref). Announcements are English to match the rest
+ * of the UI (the extension has no i18n layer).
+ */
+export interface KeyboardDndDeps {
+  /** Traversal order for ArrowLeft/Right (typically the visible areas). */
+  areas: Ref<AreaConfig[]>;
+  /** Blocks of an area, already sorted as displayed. */
+  getAreaBlocks: (areaId: string) => BlockItem[];
+  /** Same predicate the pointer DnD uses (locked / maxItems / allowedTypes / orphaned). */
+  canDrop: (block: BlockItem, area: AreaConfig) => boolean;
+  /** Perform the move (identical payload to the pointer `move-block` emit). */
+  emitMove: (payload: { blockId: BlockId; fromArea: string; toArea: string; toIndex: number }) => void;
+  /** Whether drag & drop is enabled at all (options.enableDragDrop). */
+  enabled: () => boolean;
+  /** Human-readable block title for announcements. */
+  getTitle: (block: BlockItem) => string;
+  /**
+   * Re-focus the block's element after a move re-renders the list. Receives the
+   * block id; the view resolves it to a DOM node (the element is destroyed and
+   * recreated when a block changes area, so focus must be restored explicitly).
+   */
+  focusBlock: (blockId: BlockId) => void;
+  /**
+   * Optional: let the view follow the block when it changes area (ListView shows
+   * one area at a time, so it switches the selected area to keep the block
+   * visible). GridView shows all areas at once and omits this.
+   */
+  onAreaChange?: (areaId: string) => void;
+}
+
+export function useKeyboardDnd(deps: KeyboardDndDeps) {
+  /** Id of the currently grabbed block, or null when nothing is grabbed. */
+  const grabbedId = ref<BlockId | null>(null);
+  /** Original area + index, used to restore on Escape. */
+  const origin = ref<{ area: string; index: number } | null>(null);
+  /** Latest live-region message. */
+  const announcement = ref('');
+
+  function announce(message: string): void {
+    /* Re-assigning the same string would not re-trigger the live region; clear
+       first so identical consecutive messages (e.g. repeated "skipped") still
+       get announced. */
+    announcement.value = '';
+    nextTick(() => {
+      announcement.value = message;
+    });
+  }
+
+  function isGrabbed(blockId: BlockId): boolean {
+    return grabbedId.value === blockId;
+  }
+
+  function areaById(areaId: string): AreaConfig | undefined {
+    return deps.areas.value.find((a) => a.id === areaId);
+  }
+
+  /** A block may only be grabbed if its source area allows dragging out. */
+  function canGrab(block: BlockItem): boolean {
+    if (!deps.enabled()) return false;
+    const source = areaById(block.area);
+    /* Mirror the pointer rule: locked areas can't be dragged out of, except the
+       orphaned area (which is itself never a drop target but its blocks may be
+       rescued out of it). */
+    if (source?.locked && source.id !== 'orphaned') return false;
+    return true;
+  }
+
+  function grab(block: BlockItem): void {
+    if (!canGrab(block)) {
+      announce(`${deps.getTitle(block)} can't be moved — its area is locked.`);
+      return;
+    }
+    const list = deps.getAreaBlocks(block.area);
+    const index = list.findIndex((b) => b.id === block.id);
+    grabbedId.value = block.id;
+    origin.value = { area: block.area, index };
+    const area = areaById(block.area);
+    announce(
+      `${deps.getTitle(block)} grabbed. Position ${index + 1} of ${list.length} in ${area?.label ?? block.area}. ` +
+        `Use arrow keys to move, Enter to drop, Escape to cancel.`
+    );
+    logger.log('⌨️ Keyboard DnD: grabbed', block.id, 'in', block.area);
+  }
+
+  function moveWithin(block: BlockItem, direction: -1 | 1): void {
+    const areaId = block.area;
+    const list = deps.getAreaBlocks(areaId);
+    const i = list.findIndex((b) => b.id === block.id);
+    const j = i + direction;
+    if (j < 0 || j >= list.length) {
+      announce(`Already at the ${direction < 0 ? 'top' : 'bottom'} of ${areaById(areaId)?.label ?? areaId}.`);
+      return;
+    }
+    deps.emitMove({ blockId: block.id, fromArea: areaId, toArea: areaId, toIndex: j });
+    deps.focusBlock(block.id);
+    announce(`${deps.getTitle(block)} moved to position ${j + 1} of ${list.length} in ${areaById(areaId)?.label ?? areaId}.`);
+  }
+
+  function moveAcross(block: BlockItem, direction: -1 | 1): void {
+    /* Only real areas are traversal targets; the orphaned area is never a drop
+       target, so exclude it from the left/right order. */
+    const order = deps.areas.value.filter((a) => a.id !== 'orphaned');
+    const curIdx = order.findIndex((a) => a.id === block.area);
+    let k = curIdx + direction;
+    let skipped = false;
+    while (k >= 0 && k < order.length) {
+      const target = order[k];
+      if (deps.canDrop(block, target)) {
+        const toIndex = deps.getAreaBlocks(target.id).length;
+        deps.emitMove({ blockId: block.id, fromArea: block.area, toArea: target.id, toIndex });
+        deps.onAreaChange?.(target.id);
+        deps.focusBlock(block.id);
+        announce(`${deps.getTitle(block)} moved to ${target.label}, position ${toIndex + 1} of ${toIndex + 1}.`);
+        return;
+      }
+      skipped = true;
+      k += direction;
+    }
+    announce(
+      skipped
+        ? `No available area in that direction — locked or full areas were skipped.`
+        : `No area in that direction.`
+    );
+  }
+
+  function drop(block: BlockItem): void {
+    const list = deps.getAreaBlocks(block.area);
+    const index = list.findIndex((b) => b.id === block.id);
+    announce(`${deps.getTitle(block)} dropped in ${areaById(block.area)?.label ?? block.area} at position ${index + 1}.`);
+    logger.log('⌨️ Keyboard DnD: dropped', block.id, 'in', block.area);
+    grabbedId.value = null;
+    origin.value = null;
+  }
+
+  function cancel(block: BlockItem): void {
+    if (origin.value) {
+      deps.emitMove({
+        blockId: block.id,
+        fromArea: block.area,
+        toArea: origin.value.area,
+        toIndex: origin.value.index,
+      });
+      deps.onAreaChange?.(origin.value.area);
+      deps.focusBlock(block.id);
+    }
+    announce(`Move cancelled. ${deps.getTitle(block)} returned to its original position.`);
+    logger.log('⌨️ Keyboard DnD: cancelled', block.id);
+    grabbedId.value = null;
+    origin.value = null;
+  }
+
+  /**
+   * Keydown handler bound to each block's grab element. The view passes the
+   * block currently rendered at that element.
+   */
+  function handleBlockKeydown(event: KeyboardEvent, block: BlockItem): void {
+    if (!deps.enabled()) return;
+    const key = event.key;
+
+    if (grabbedId.value === null) {
+      if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+        event.preventDefault();
+        event.stopPropagation();
+        grab(block);
+      }
+      return;
+    }
+
+    /* Grabbed mode: only react to the grabbed block; ignore stray keys elsewhere. */
+    if (grabbedId.value !== block.id) return;
+
+    switch (key) {
+      case 'Escape':
+        event.preventDefault();
+        event.stopPropagation();
+        cancel(block);
+        break;
+      case 'Enter':
+      case ' ':
+      case 'Spacebar':
+        event.preventDefault();
+        event.stopPropagation();
+        drop(block);
+        break;
+      case 'Tab':
+        /* Movement is arrows-only while grabbed. */
+        event.preventDefault();
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        event.stopPropagation();
+        moveWithin(block, -1);
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        event.stopPropagation();
+        moveWithin(block, 1);
+        break;
+      case 'ArrowLeft':
+        event.preventDefault();
+        event.stopPropagation();
+        moveAcross(block, -1);
+        break;
+      case 'ArrowRight':
+        event.preventDefault();
+        event.stopPropagation();
+        moveAcross(block, 1);
+        break;
+    }
+  }
+
+  return {
+    announcement,
+    grabbedId,
+    isGrabbed,
+    handleBlockKeydown,
+  };
+}

--- a/src/composables/useKeyboardDnd.ts
+++ b/src/composables/useKeyboardDnd.ts
@@ -179,7 +179,7 @@ export function useKeyboardDnd(deps: KeyboardDndDeps) {
     const key = event.key;
 
     if (grabbedId.value === null) {
-      if (key === 'Enter' || key === ' ' || key === 'Spacebar') {
+      if (key === 'Enter' || key === ' ') {
         event.preventDefault();
         event.stopPropagation();
         grab(block);
@@ -198,7 +198,6 @@ export function useKeyboardDnd(deps: KeyboardDndDeps) {
         break;
       case 'Enter':
       case ' ':
-      case 'Spacebar':
         event.preventDefault();
         event.stopPropagation();
         drop(block);

--- a/src/directives/btnAria.ts
+++ b/src/directives/btnAria.ts
@@ -1,0 +1,43 @@
+import type { Directive } from 'vue';
+
+/**
+ * Forwards ARIA / role / tabindex attributes onto the inner native `<button>`
+ * of a Directus `v-button`.
+ *
+ * Directus' `v-button` renders `<div class="v-button"><button>…</button></div>`
+ * with `inheritAttrs: true`, so Vue's attribute fallthrough puts any `role` /
+ * `aria-*` / `tabindex` we set in the template on the **wrapper `<div>`**, not on
+ * the focusable `<button>`. A screen reader then meets an unlabeled, role-less
+ * generic button. This directive copies the given attributes onto the actual
+ * `<button>` where they belong, and re-applies on every update so reactive
+ * values (`aria-checked`, `aria-expanded`, roving `tabindex`) stay in sync.
+ *
+ * `null` / `undefined` removes the attribute; `false` is rendered as the string
+ * `"false"` (meaningful for `aria-checked` / `aria-expanded`).
+ *
+ * Usage:
+ *   <v-button v-btn-aria="{ 'aria-label': 'Manage areas' }" … />
+ *   <v-button v-btn-aria="{ role: 'radio', 'aria-checked': isActive, tabindex: isActive ? 0 : -1 }" … />
+ */
+type AriaAttrs = Record<string, string | number | boolean | null | undefined>;
+
+function applyAttrs(el: HTMLElement, value: AriaAttrs): void {
+  const btn: HTMLElement | null = el.matches('button') ? el : el.querySelector('button');
+  if (!btn) return;
+  for (const [key, val] of Object.entries(value || {})) {
+    if (val === null || val === undefined) {
+      btn.removeAttribute(key);
+    } else {
+      btn.setAttribute(key, String(val));
+    }
+  }
+}
+
+export const vBtnAria: Directive<HTMLElement, AriaAttrs> = {
+  mounted(el, binding) {
+    applyAttrs(el, binding.value);
+  },
+  updated(el, binding) {
+    applyAttrs(el, binding.value);
+  },
+};

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -63,6 +63,7 @@
           <v-button
             v-if="options.enableAreaManagement"
             v-tooltip="'Manage areas'"
+            aria-label="Manage areas"
             icon
             secondary
             @click="showAreaManager = true"
@@ -75,11 +76,13 @@
           <!-- Area selector: switches the active area, driving the view's
                v-model:selected-area (ListView tabs / GridView card highlight). -->
           <v-menu v-if="computedAreas.length" show-arrow placement="bottom">
-            <template #activator="{ toggle }">
+            <template #activator="{ toggle, active }">
               <v-button
                 secondary
                 small
                 class="area-select"
+                aria-haspopup="menu"
+                :aria-expanded="active"
                 @click="toggle"
               >
                 <v-icon
@@ -126,24 +129,36 @@
         </div>
 
         <div class="toolbar-right">
-          <v-button-group>
+          <v-button-group role="radiogroup" aria-label="View mode">
             <v-button
               v-tooltip="'Grid view'"
+              aria-label="Grid view"
+              role="radio"
+              data-view="grid"
+              :aria-checked="viewMode === 'grid'"
+              :tabindex="viewMode === 'grid' ? 0 : -1"
               :active="viewMode === 'grid'"
               secondary
               icon
               small
               @click="viewMode = 'grid'"
+              @keydown="handleViewKeydown"
             >
               <v-icon name="grid_view" />
             </v-button>
             <v-button
               v-tooltip="'List view'"
+              aria-label="List view"
+              role="radio"
+              data-view="list"
+              :aria-checked="viewMode === 'list'"
+              :tabindex="viewMode === 'list' ? 0 : -1"
               :active="viewMode === 'list'"
               secondary
               icon
               small
               @click="viewMode = 'list'"
+              @keydown="handleViewKeydown"
             >
               <v-icon name="view_list" />
             </v-button>
@@ -180,6 +195,8 @@
         v-model="showBlockCreator"
         :title="null"
         persistent
+        aria-labelledby="lb-block-creator-title"
+        @esc="showBlockCreator = false"
       >
         <template #default>
           <block-creator
@@ -242,6 +259,7 @@
         icon="edit"
         persistent
         @cancel="handleDrawerCancel"
+        @esc="handleDrawerCancel"
       >
 
         
@@ -276,6 +294,7 @@
         icon="dashboard_customize"
         persistent
         @cancel="showAreaManager = false"
+        @esc="showAreaManager = false"
       >
         <area-manager
           v-if="showAreaManager"
@@ -515,6 +534,35 @@ const editSaving = ref(false);
 const editForm = ref<any>(null);
 const fieldOptions = ref<any>(null);
 const areaManagerRef = ref<any>(null);
+
+// View toggle is a radiogroup (a11y §2): ←/→ switches modes and moves focus to
+// the now-selected button (roving tabindex).
+function handleViewKeydown(event: KeyboardEvent) {
+  if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+  event.preventDefault();
+  viewMode.value = viewMode.value === 'grid' ? 'list' : 'grid';
+  nextTick(() => {
+    const btn = toolbarEl.value?.querySelector(`[data-view="${viewMode.value}"]`);
+    (btn as HTMLElement | null)?.focus();
+  });
+}
+
+// Return focus to the trigger when a dialog/drawer closes (a11y §2). Capturing
+// document.activeElement at open time covers the common triggers (toolbar /
+// action buttons); a detached trigger just no-ops on restore.
+const lastOverlayTrigger = ref<HTMLElement | null>(null);
+function rememberOverlayTrigger() {
+  const el = document.activeElement;
+  lastOverlayTrigger.value = el instanceof HTMLElement ? el : null;
+}
+function restoreOverlayTrigger() {
+  const el = lastOverlayTrigger.value;
+  lastOverlayTrigger.value = null;
+  if (el && document.contains(el)) nextTick(() => el.focus());
+}
+watch(showAreaManager, (open, was) => { if (open) rememberOverlayTrigger(); else if (was) restoreOverlayTrigger(); });
+watch(showBlockCreator, (open, was) => { if (open) rememberOverlayTrigger(); else if (was) restoreOverlayTrigger(); });
+watch(drawerActive, (open, was) => { if (open) rememberOverlayTrigger(); else if (was) restoreOverlayTrigger(); });
 
 // Toolbar sticky-shadow: show a subtle shadow under the toolbar only once it is
 // stuck to the top (matching Directus' own header-bar). An IntersectionObserver

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -63,7 +63,7 @@
           <v-button
             v-if="options.enableAreaManagement"
             v-tooltip="'Manage areas'"
-            aria-label="Manage areas"
+            v-btn-aria="{ 'aria-label': 'Manage areas' }"
             icon
             secondary
             @click="showAreaManager = true"
@@ -81,8 +81,7 @@
                 secondary
                 small
                 class="area-select"
-                aria-haspopup="menu"
-                :aria-expanded="active"
+                v-btn-aria="{ 'aria-haspopup': 'menu', 'aria-expanded': active }"
                 @click="toggle"
               >
                 <v-icon
@@ -132,11 +131,7 @@
           <v-button-group role="radiogroup" aria-label="View mode">
             <v-button
               v-tooltip="'Grid view'"
-              aria-label="Grid view"
-              role="radio"
-              data-view="grid"
-              :aria-checked="viewMode === 'grid'"
-              :tabindex="viewMode === 'grid' ? 0 : -1"
+              v-btn-aria="{ role: 'radio', 'aria-label': 'Grid view', 'aria-checked': viewMode === 'grid', tabindex: viewMode === 'grid' ? 0 : -1, 'data-view': 'grid' }"
               :active="viewMode === 'grid'"
               secondary
               icon
@@ -148,11 +143,7 @@
             </v-button>
             <v-button
               v-tooltip="'List view'"
-              aria-label="List view"
-              role="radio"
-              data-view="list"
-              :aria-checked="viewMode === 'list'"
-              :tabindex="viewMode === 'list' ? 0 : -1"
+              v-btn-aria="{ role: 'radio', 'aria-label': 'List view', 'aria-checked': viewMode === 'list', tabindex: viewMode === 'list' ? 0 : -1, 'data-view': 'list' }"
               :active="viewMode === 'list'"
               secondary
               icon
@@ -327,6 +318,7 @@
 
 <script setup lang="ts">
 import { logger } from './utils/logger';
+import { vBtnAria } from './directives/btnAria';
 import { ref, computed, watch, onMounted, onUnmounted, inject, resolveComponent, nextTick, useAttrs, getCurrentInstance } from 'vue';
 import { useApi, useStores, useCollection } from '@directus/extensions-sdk';
 import { M2AHelper } from './utils/m2a-helper';

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -128,7 +128,7 @@
         </div>
 
         <div class="toolbar-right">
-          <v-button-group role="radiogroup" aria-label="View mode">
+          <div class="lb-view-toggle" role="radiogroup" aria-label="View mode">
             <v-button
               v-tooltip="'Grid view'"
               v-btn-aria="{ role: 'radio', 'aria-label': 'Grid view', 'aria-checked': viewMode === 'grid', tabindex: viewMode === 'grid' ? 0 : -1, 'data-view': 'grid' }"
@@ -153,7 +153,7 @@
             >
               <v-icon name="view_list" />
             </v-button>
-          </v-button-group>
+          </div>
         </div>
       </div>
 
@@ -1905,6 +1905,15 @@ watch(() => props.value, () => {
   .toolbar-center {
     flex: 1;
     justify-content: center;
+  }
+
+  /* View-mode toggle (Grid/List): replaces the bare <v-button-group> element,
+     which is not a registered Directus component (it rendered as an unstyled
+     literal element, so the two icon buttons sat edge-to-edge with no gap). */
+  .lb-view-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
   }
 
   /* Area selector trigger (v-menu activator): a native v-button showing the


### PR DESCRIPTION
## Summary
Accessibility & keyboard hardening pass across the whole extension (implements `docs/design/design_handoff_layout_blocks/KEYBOARD_AND_A11Y.md`).

- **Keyboard drag & drop** (both views) via a new shared `useKeyboardDnd` composable: the focused block is the grab target (Enter/Space grab+drop, ↑/↓ within an area, ←/→ across areas skipping locked/incompatible, Esc cancel), with a visually-hidden `aria-live="polite"` region announcing every step. Reuses the existing `canDropInArea` rules; the missing `locked` check was folded into GridView so both views (and mouse + keyboard) share one predicate.
- **Focus rings**: `:focus-visible` outline via `--theme--form--field--input--focus-ring-color` on every custom interactive element (grid/area cards, block cards, list tabs, drag handle, status pill, wizard tiles). Native `v-*` components keep Directus' own ring.
- **ARIA roles/labels**: view-toggle & list tabs = `radiogroup` (←/→, roving tabindex); grid area cards `role="group"`, blocks `role="listitem"`; list table `role="grid"`/`row`; status selector `aria-haspopup="listbox"`/`aria-expanded` + options `role="option"`/`aria-selected`; add-dropdown `aria-haspopup="menu"`; delete dialog `role="radiogroup"`; dialogs/drawers `aria-labelledby` + return-focus + Esc=cancel; 9 icon-only buttons get `aria-label`.
- **Reduced motion**: `@media (prefers-reduced-motion: reduce)` disables entrance/drag/hover animations in grid/list/block/wizard.
- Status stays dot **+** label (no white-on-success); inline-edit keyboard (Enter/F2/Tab/Esc) was already in place from #54/#55.

## Decisions
- Grid block grab target = the card itself (no new handle icon, keeps the #55 visual).
- `persistent` drawers/dialog kept (outside-click still guards unsaved edits) + explicit Esc=cancel + return-focus.

## Test plan
- [x] `npm run type-check`, `npm run lint` (0 errors), `npm run test -- --run` (48 passed), `npm run build` — all green.
- [x] Smoke page-load on `layout_demo/1` renders with 0 console errors.
- [ ] **Live (/pt)**: keyboard-only walkthrough in grid + list, light + dark — tab order, focus rings, view-toggle ←/→, keyboard DnD (grab/move/cross-area/cancel + announcements), status listbox, dialog/drawer Esc + return-focus.
- [ ] Verify Directus `v-button`/`v-button-group` forward `role`/`tabindex`/`aria-*`/`@keydown`; verify `@esc` fires on the `persistent` drawers (else add a manual keydown listener).

Closes #56