### PR TITLE
Theme QA + reachable block wizard, drawer & toolbar fixes

### DIFF
--- a/src/components/BlockCreator.vue
+++ b/src/components/BlockCreator.vue
@@ -455,6 +455,24 @@ watch(() => props.selectedArea, (newArea) => {
   if (newArea) localArea.value = newArea;
 });
 
+/* The ItemSelector drawer opens from INSIDE the wizard v-dialog. Directus dialogs
+   (z-index 850) stack above drawers (500), so the drawer would render BEHIND the
+   wizard and be unusable. Scoped CSS can't reach it (it teleports to <body>) and a
+   wrapper class doesn't help (v-drawer re-teleports its container out of the
+   wrapper) — so raise the just-opened drawer's container above the dialog
+   imperatively. Only the wizard's own drawer is open during this flow, so this
+   targets the right one; the inline style dies with the element on close. */
+const DRAWER_ABOVE_DIALOG_Z = '900';
+watch(showItemSelector, (open) => {
+  if (!open) return;
+  nextTick(() => {
+    const container = document.querySelector('.v-drawer')?.closest('.container');
+    if (container instanceof HTMLElement) {
+      container.style.zIndex = DRAWER_ABOVE_DIALOG_Z;
+    }
+  });
+});
+
 // Focus the first sensible control when the dialog opens (a11y §2). The card is
 // teleported to <body> by v-dialog, so query it there; best-effort (native
 // focus-trap keeps focus inside the dialog regardless).
@@ -501,7 +519,7 @@ onMounted(() => {
 .wizard-step-num {
   width: 22px;
   height: 22px;
-  border-radius: 50%;
+  border-radius: var(--theme--border-radius);
   background: var(--theme--background-normal);
   display: flex;
   align-items: center;

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -128,6 +128,18 @@
         </div>
 
         <div class="toolbar-right">
+          <!-- Guided "add a block" entry point (opens the BlockCreator wizard).
+               Always reachable, unlike the per-area quick-add which only the
+               area headers / empty states expose; preselects the current area. -->
+          <v-button
+            v-if="permissions.create"
+            small
+            secondary
+            @click="openBlockCreator(selectedArea ?? undefined)"
+          >
+            <v-icon name="add" left />
+            Add block
+          </v-button>
           <div class="lb-view-toggle" role="radiogroup" aria-label="View mode">
             <v-button
               v-tooltip="'Grid view'"
@@ -1876,7 +1888,6 @@ watch(() => props.value, () => {
   align-items: center;
   justify-content: space-between;
   padding: var(--theme--form--field--input--padding, 12px) 0;
-  border-bottom: var(--theme--border-width) solid var(--theme--border-color);
   flex-shrink: 0;
   /* Sticky so the view toggle and area selector stay reachable while scrolling,
      and to show a subtle shadow once stuck (like Directus' own header-bar).
@@ -1889,8 +1900,11 @@ watch(() => props.value, () => {
   background: var(--theme--background);
   transition: box-shadow 0.2s;
 
-  /* Subtle elevation once stuck, matching Directus' own header-bar shadow. */
+  /* Separation only once stuck (border + subtle elevation, like Directus' own
+     header-bar). At rest the toolbar blends into the page — no bottom line/shadow,
+     which otherwise reads as a stray drop-shadow when nothing is scrolled under it. */
   &.is-stuck {
+    border-bottom: var(--theme--border-width) solid var(--theme--border-color);
     box-shadow: var(--theme--header--box-shadow);
   }
 


### PR DESCRIPTION
## Summary
Final redesign sub-issue (#57): theme-QA Definition-of-Done pass, plus a few fixes folded in (the wizard was unreachable and its link flow was broken; the toolbar showed a stray separator at rest).

**Theme QA (the #57 gate):**
- Grep gates pass over `src/**/*.{vue,ts}`: zero legacy `--*` variables, zero `rgb()`/`rgba()`, zero literal `black`/`white`. The only literals are 3x documented `#fff`-on-primary/success (`--foreground-inverted`, AA-verified) + `border-radius: 50%` on the status dot.
- All surfaces verified in light + dark + a custom primary (transient teal): selection / focus-ring / active states derive correctly from `--theme--primary` (incl. the derived `-background` color-mix tints).
- Depth staffelung holds in dark — page `#0d1117` -> recessed area `#161b22` -> header `#30363d` -> block card `#0d1117`, no collapsed layers.
- Contrast watch-list respected (status is dot + label, no white-on-success; status text in `--theme--foreground`).
- `wizard-step-num` radius switched from `50%` to `var(--theme--border-radius)` for strict gate compliance.

**Folded-in fixes (requested during QA):**
- **Toolbar "Add block" button** — opens the BlockCreator wizard globally (it was only reachable from an empty area's "Add First Block"); preselects the current area.
- **Wizard "Link/Duplicate existing" drawer** rendered behind the wizard dialog (Directus dialogs z-index 850 > drawers 500) — now raised above it so items are selectable.
- **Toolbar separation** (border + shadow) now appears only when the toolbar is stuck; at rest it blends into the page (previously an always-on bottom border read as a stray drop-shadow).

## Test plan
- [x] `npm run type-check`, `npm run lint` (0 errors), `npm run test -- --run` (48 passed), `npm run build` - all green.
- [x] Live (Playwright): grep gates; light + dark + custom-primary across surfaces; depth + contrast in dark; wizard reachable via the toolbar; ItemSelector drawer in front + clickable; toolbar clean at rest, separated when stuck.

Closes #57