### PR TITLE
Final audit fixes: ListView delete dialog, EmptyState unify, polish

### DIFF
--- a/src/components/AreaManager.vue
+++ b/src/components/AreaManager.vue
@@ -275,10 +275,11 @@
           </table>
         </div>
 
-        <div v-else class="empty-state">
-          <v-icon name="dashboard_customize" large />
-          <p>No areas defined yet — use "Add area" to create one.</p>
-        </div>
+        <EmptyState
+          v-else
+          icon="dashboard_customize"
+          message='No areas defined yet — use "Add area" to create one.'
+        />
 
         <!--
           Explains the locked-row treatment (lock icon + disabled inline edit).
@@ -296,6 +297,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, nextTick } from 'vue';
 import { vBtnAria } from '../directives/btnAria';
+import EmptyState from './EmptyState.vue';
 import { cloneDeep } from 'lodash-es';
 import draggable from 'vuedraggable';
 import type { AreaConfig } from '../types';
@@ -591,12 +593,13 @@ function save() {
   }
 }
 
-// Icon picker placeholder
+// Icon picker placeholder — the real picker is a separate follow-up (#64).
+// Friendly "coming soon" copy instead of a dev "not implemented" string.
 const IconPicker = {
   template: `
     <div class="icon-picker">
-      <p style="padding: 12px; color: var(--theme--foreground-subdued);">
-        Icon picker not implemented
+      <p style="padding: var(--theme--form--field--input--padding, 12px); color: var(--theme--foreground-subdued); white-space: nowrap;">
+        Custom icon picker coming soon
       </p>
     </div>
   `
@@ -771,6 +774,14 @@ defineExpose({
   opacity: 1;
 }
 
+/* Reduced motion (a11y §5): no hover/affordance transitions. */
+@media (prefers-reduced-motion: reduce) {
+  .editable-value,
+  .edit-pencil {
+    transition: none;
+  }
+}
+
 .collections-list {
   display: flex;
   flex-direction: column;
@@ -793,12 +804,6 @@ defineExpose({
   .v-button {
     margin-top: 4px;
   }
-}
-
-.empty-state {
-  text-align: center;
-  padding: 40px;
-  color: var(--theme--foreground-subdued);
 }
 
 .locked-hint {

--- a/src/components/EmptyState.vue
+++ b/src/components/EmptyState.vue
@@ -1,15 +1,18 @@
 <template>
-  <div class="empty-state">
+  <div class="empty-state" :class="{ dense }">
     <v-icon :name="icon" large />
     <p>{{ message }}</p>
-    <v-button
-      v-if="showAction && actionLabel"
-      :small="small"
-      :secondary="secondary"
-      @click="$emit('action')"
-    >
-      {{ actionLabel }}
-    </v-button>
+    <!-- Custom action (e.g. an AddBlockDropdown); falls back to a plain button. -->
+    <slot name="action">
+      <v-button
+        v-if="showAction && actionLabel"
+        :small="small"
+        :secondary="secondary"
+        @click="$emit('action')"
+      >
+        {{ actionLabel }}
+      </v-button>
+    </slot>
   </div>
 </template>
 
@@ -21,13 +24,16 @@ interface Props {
   actionLabel?: string;
   small?: boolean;
   secondary?: boolean;
+  /** Tighter padding/min-height for constrained contexts (e.g. a grid area card). */
+  dense?: boolean;
 }
 
 withDefaults(defineProps<Props>(), {
   icon: 'inbox',
   showAction: false,
   small: false,
-  secondary: false
+  secondary: false,
+  dense: false
 });
 
 defineEmits<{
@@ -46,6 +52,12 @@ defineEmits<{
   color: var(--theme--foreground-subdued);
   text-align: center;
   min-height: 200px;
+
+  &.dense {
+    gap: 12px;
+    padding: 16px;
+    min-height: 120px;
+  }
 
   p {
     margin: 0;

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -85,20 +85,24 @@
             />
           </transition-group>
 
-          <!-- Empty State -->
-          <div v-else class="area-empty">
-            <v-icon name="inbox" large />
-            <p>{{ area.locked ? 'Area is locked' : 'No blocks in this area' }}</p>
-            <AddBlockDropdown
-              v-if="!area.locked && permissions.create"
-              :area="area.id"
-              :allowed-collections="allowedCollections"
-              size="small"
-              variant="secondary"
-              @create-block="$emit('create-quick', $event)"
-              @open-selector="$emit('open-selector', $event)"
-            />
-          </div>
+          <!-- Empty State (shared EmptyState, dense for the constrained area card) -->
+          <EmptyState
+            v-else
+            dense
+            icon="inbox"
+            :message="area.locked ? 'Area is locked' : 'No blocks in this area'"
+          >
+            <template v-if="!area.locked && permissions.create" #action>
+              <AddBlockDropdown
+                :area="area.id"
+                :allowed-collections="allowedCollections"
+                size="small"
+                variant="secondary"
+                @create-block="$emit('create-quick', $event)"
+                @open-selector="$emit('open-selector', $event)"
+              />
+            </template>
+          </EmptyState>
         </div>
 
         <!-- Area Footer -->
@@ -132,6 +136,7 @@ import type {
   UserPermissions
 } from '../types';
 import BlockItemComponent from './BlockItem.vue';
+import EmptyState from './EmptyState.vue';
 import { createDragImage, getBlockTitle } from '../utils/blockHelpers';
 import { useKeyboardDnd } from '../composables/useKeyboardDnd';
 
@@ -660,25 +665,9 @@ function handleAddBlock(areaId: string) {
   gap: 8px;
 }
 
-.area-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  min-height: 120px;
-  text-align: center;
-  color: var(--theme--foreground-subdued);
-
-  p {
-    margin: 8px 0 16px;
-    font-size: 14px;
-  }
-}
-
 .area-footer {
   padding: 8px 12px;
-  border-top: 1px solid var(--theme--border-color-subdued);
+  border-top: var(--theme--border-width) solid var(--theme--border-color-subdued);
   display: flex;
   align-items: center;
   gap: 8px;

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -215,7 +215,7 @@
                     x-small
                     secondary
                     class="danger"
-                    @click="confirmRemove(block.id)"
+                    @click="openDeleteDialog(block)"
                   >
                     <v-icon name="delete" />
                   </v-button>
@@ -253,6 +253,15 @@
 
     <!-- Visually-hidden live region: announces keyboard drag & drop steps. -->
     <div class="lb-sr-only" role="status" aria-live="polite">{{ kbAnnouncement }}</div>
+
+    <delete-confirmation-dialog
+      v-model="showDeleteDialog"
+      :block-title="blockToDelete ? getBlockTitle(blockToDelete) : ''"
+      :can-delete="canDeleteContent"
+      :loading="deleteLoading"
+      @confirm="handleDeleteConfirm"
+      @cancel="showDeleteDialog = false"
+    />
   </div>
 </template>
 
@@ -262,6 +271,7 @@ import { ref, computed, onMounted, watch, nextTick } from 'vue';
 import AddBlockDropdown from './AddBlockDropdown.vue';
 import StatusSelector from './StatusSelector.vue';
 import EmptyState from './EmptyState.vue';
+import DeleteConfirmationDialog from './DeleteConfirmationDialog.vue';
 import { createDragImage } from '../utils/blockHelpers';
 import { useKeyboardDnd } from '../composables/useKeyboardDnd';
 import { vBtnAria } from '../directives/btnAria';
@@ -295,7 +305,8 @@ const emit = defineEmits<{
     toArea: string;
     toIndex: number;
   }];
-  'remove-block': [blockId: BlockId];
+  'unlink-block': [blockId: BlockId];
+  'delete-block': [blockId: BlockId, deleteContent: boolean];
   'duplicate-block': [blockId: BlockId];
   'update-block': [data: { blockId: BlockId; updates?: any }];
   'add-block': [area?: string];
@@ -537,10 +548,34 @@ function getCollectionLabel(block: BlockItem): string {
     .replace(/^Content /, '');
 }
 
-function confirmRemove(blockId: number) {
-  if (confirm('Are you sure you want to remove this block?')) {
-    emit('remove-block', blockId);
+/* Remove uses the redesigned DeleteConfirmationDialog (unassign vs delete),
+   consistent with the grid/block-card path — not a native confirm(). */
+const blockToDelete = ref<BlockItem | null>(null);
+const showDeleteDialog = ref(false);
+const deleteLoading = ref(false);
+
+const canDeleteContent = computed(() =>
+  !!props.permissions.delete && blockToDelete.value?.item != null
+);
+
+function openDeleteDialog(block: BlockItem) {
+  blockToDelete.value = block;
+  showDeleteDialog.value = true;
+}
+
+function handleDeleteConfirm(options: { deleteContent: boolean }) {
+  if (!blockToDelete.value) return;
+  deleteLoading.value = true;
+  if (options.deleteContent) {
+    emit('delete-block', blockToDelete.value.id, true);
+  } else {
+    emit('unlink-block', blockToDelete.value.id);
   }
+  setTimeout(() => {
+    showDeleteDialog.value = false;
+    deleteLoading.value = false;
+    blockToDelete.value = null;
+  }, 100);
 }
 
 function updateBlockStatus(block: BlockItem, newStatus: string) {

--- a/src/components/StatusSelector.vue
+++ b/src/components/StatusSelector.vue
@@ -93,6 +93,13 @@ defineEmits<{
     color: var(--theme--foreground);
   }
 }
+
+/* Reduced motion (a11y §5): no hover transition. */
+@media (prefers-reduced-motion: reduce) {
+  .status-display {
+    transition: none;
+  }
+}
 </style>
 
 <style lang="scss">

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -1908,6 +1908,11 @@ watch(() => props.value, () => {
     box-shadow: var(--theme--header--box-shadow);
   }
 
+  /* Reduced motion (a11y §5): no shadow transition. */
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+
   .toolbar-left,
   .toolbar-center,
   .toolbar-right {


### PR DESCRIPTION
## Summary
Final pre-`main` polish from a rigorous epic-wide audit (all of #48–#57 merged on epic/47). The token gates were already clean; this addresses the functional/consistency gaps the audit surfaced:

- **ListView "Remove" now uses the redesigned `DeleteConfirmationDialog`** (unassign vs. delete, with the #56 radiogroup a11y) instead of a native `window.confirm()` — consistent with the grid/block-card path. Verified end-to-end (dialog opens, "Unassign" removes the block).
- **Unified `EmptyState`**: GridView's area-empty + AreaManager's empty panel now use the shared `EmptyState` component (added an `#action` slot for the AddBlockDropdown + a `dense` variant for the constrained grid card); removed the two inline variants + their dead SCSS.
- **Reduced-motion** guards added to StatusSelector / AreaManager / interface toolbar (the components that still had bare hover/affordance transitions).
- **Token polish**: GridView area-footer hairline `1px` -> `var(--theme--border-width)`.
- **Icon-picker stub** copy softened ("Icon picker not implemented" -> "Custom icon picker coming soon"); the real picker remains follow-up #64.

## Test plan
- [x] `npm run type-check`, `npm run lint` (0 errors), `npm run test -- --run` (48 passed), `npm run build` - all green.
- [x] Live (Playwright): ListView Remove -> DeleteConfirmationDialog (no native confirm) -> "Unassign" removes block end-to-end; GridView empty area renders the shared `EmptyState` (dense + AddBlockDropdown action).

Part of #47