### PR TITLE
AreaManager: real icon picker + fix allowed-collections source

### DIFF
--- a/src/components/AreaManager.vue
+++ b/src/components/AreaManager.vue
@@ -38,7 +38,19 @@
                   </td>
 
                   <td class="icon-cell">
-                    <v-menu v-if="!area.locked" show-arrow placement="bottom">
+                    <!-- Curated icon picker: a compact v-button trigger opens a
+                         v-icon grid (AREA_ICON_CHOICES). Chosen over the native
+                         interface-select-icon, whose teleported, full-width,
+                         virtual-scrolled menu does not fit this table cell (#64).
+                         Uncontrolled v-menu (activator `toggle`) + v-list-item —
+                         the same proven pattern as the allowed-collections menu
+                         below; the menu closes itself on item click. Locked rows
+                         show a static icon (no editing). -->
+                    <v-menu
+                      v-if="!area.locked"
+                      show-arrow
+                      placement="bottom-start"
+                    >
                       <template #activator="{ toggle, active }">
                         <v-button
                           icon
@@ -49,7 +61,20 @@
                           <v-icon :name="area.icon || 'dashboard_customize'" />
                         </v-button>
                       </template>
-                      <icon-picker v-model="area.icon" />
+                      <v-list class="icon-picker-grid">
+                        <v-list-item
+                          v-for="choice in AREA_ICON_CHOICES"
+                          :key="choice"
+                          clickable
+                          :active="(area.icon || 'dashboard_customize') === choice"
+                          class="icon-choice"
+                          v-tooltip="choice"
+                          :aria-label="choice"
+                          @click="pickAreaIcon(area, choice)"
+                        >
+                          <v-icon :name="choice" />
+                        </v-list-item>
+                      </v-list>
                     </v-menu>
                     <v-icon
                       v-else
@@ -301,7 +326,7 @@ import EmptyState from './EmptyState.vue';
 import { cloneDeep } from 'lodash-es';
 import draggable from 'vuedraggable';
 import type { AreaConfig } from '../types';
-import { WIDTH_OPTIONS } from '../utils/constants';
+import { WIDTH_OPTIONS, AREA_ICON_CHOICES } from '../utils/constants';
 import { validateAreaConfig, sanitizeAreaId } from '../utils/validators';
 
 // Props
@@ -374,6 +399,13 @@ function addArea() {
 function removeArea(index: number) {
   localAreas.value.splice(index, 1);
   validateAreas();
+}
+
+// Picks an area's icon from the curated grid. Like the inline-edit mutators, this
+// edits the local working copy; the parent only receives it on "Save Areas". The
+// v-menu closes itself when a v-list-item is clicked (Directus default).
+function pickAreaIcon(area: AreaConfig, icon: string) {
+  area.icon = icon;
 }
 
 function validateAreas() {
@@ -593,18 +625,6 @@ function save() {
   }
 }
 
-// Icon picker placeholder — the real picker is a separate follow-up (#64).
-// Friendly "coming soon" copy instead of a dev "not implemented" string.
-const IconPicker = {
-  template: `
-    <div class="icon-picker">
-      <p style="padding: var(--theme--form--field--input--padding, 12px); color: var(--theme--foreground-subdued); white-space: nowrap;">
-        Custom icon picker coming soon
-      </p>
-    </div>
-  `
-};
-
 // Expose for parent
 defineExpose({
   save,
@@ -701,6 +721,35 @@ defineExpose({
       }
     }
   }
+}
+
+/* Curated icon picker grid (issue #64). Uses native v-list-item — the proven
+   clickable-menu pattern already used for the allowed-collections menu in this
+   component (raw <button>s inside the teleported v-menu content do not receive
+   clicks). The v-list / v-list-item roots carry the AreaManager scope id even
+   though v-menu teleports the content, so scoped :deep styles reach them — no
+   global leak. v-list-item provides native hover/active styling (active = the
+   currently selected icon). */
+.icon-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 2px;
+  padding: 4px;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.icon-picker-grid :deep(.icon-choice) {
+  min-width: 0;
+  width: 32px;
+  height: 32px;
+  min-height: 32px;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--theme--border-radius);
 }
 
 .drag-handle {

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -339,7 +339,7 @@ import { useBlocks } from './composables/useBlocks';
 import { usePermissions } from './composables/usePermissions';
 import { useBlockPermissions } from './composables/useBlockPermissions';
 import { DEFAULT_OPTIONS, DEFAULT_AREA_CONFIG } from './utils/constants';
-import { normalizeAreaIds, isTempId } from './utils/helpers';
+import { normalizeAreaIds, isTempId, formatCollectionName } from './utils/helpers';
 import { cloneDeep } from 'lodash-es';
 import { CUSTOM_AREAS, USE_CUSTOM_AREAS } from './config/areas';
 import type {
@@ -745,32 +745,38 @@ const allowedCollections = computed(() => {
   return null;
 });
 
-// Format allowed collections for the AreaManager
+// Build a { text, value } option for the AreaManager collection picker, reusing
+// the Directus collection display name (falls back to a prettified key).
+function formatCollectionOption(collectionName: string): { text: string; value: string } {
+  return {
+    text: collectionsStore.getCollection(collectionName)?.name || formatCollectionName(collectionName),
+    value: collectionName
+  };
+}
+
+// Format allowed collections for the AreaManager.
 const formattedAllowedCollections = computed(() => {
-  // Get the allowed collections from the computed property
   const allowed = allowedCollections.value;
-  
-  // If no collections are allowed, return empty array
-  if (!allowed || allowed.length === 0) {
-    return [];
+
+  // Restricted: the field/interface limits the M2A to an explicit subset — offer
+  // exactly that subset (unchanged behavior).
+  if (allowed && allowed.length > 0) {
+    return allowed.map(formatCollectionOption);
   }
-  
-  // Get collection details from collectionsStore if available
-  const collections = collectionsStore.collections;
-  
-  // Format the collections
-  const formatted = allowed.map(collectionName => {
-    const collection = collections?.[collectionName];
-    return {
-      text: collection?.name || collectionName
-        .split('_')
-        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
-        .join(' '),
-      value: collectionName
-    };
-  });
-  
-  return formatted;
+
+  // Unrestricted (allowedCollections === null): the M2A field accepts any
+  // collection, so list every eligible content collection instead of an empty
+  // array (issue #64). Excludes system collections, schema-less folder/group
+  // pseudo-collections, hidden collections, and the M2A junction itself.
+  const junctionCollection = junctionInfo.value?.collection;
+  return collectionsStore.collections
+    .filter((collection: any) =>
+      !collection.collection.startsWith('directus_') &&
+      collection.schema != null &&
+      collection.meta?.hidden !== true &&
+      collection.collection !== junctionCollection
+    )
+    .map((collection: any) => formatCollectionOption(collection.collection));
 });
 
 // Initialize ItemSelector after allowedCollections is defined

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -81,3 +81,16 @@ export const WIDTH_OPTIONS = [
   { text: 'Two Thirds (66%)', value: 66 },
   { text: 'Three Quarters (75%)', value: 75 }
 ];
+
+// Curated icon choices for the AreaManager icon picker — a bounded, layout/section
+// focused set (Material Symbols) rendered as a v-icon grid. Chosen over the native
+// `interface-select-icon` interface, whose teleported, full-width, virtual-scrolled
+// menu does not fit a compact table cell (issue #64). Includes the icons used by the
+// default/locked areas so existing values are always representable in the grid.
+export const AREA_ICON_CHOICES = [
+  'dashboard', 'dashboard_customize', 'grid_view', 'view_quilt', 'view_column', 'view_agenda',
+  'view_day', 'view_carousel', 'view_sidebar', 'vertical_split', 'horizontal_split', 'web',
+  'horizontal_rule', 'table_rows', 'calendar_view_day', 'vertical_align_top', 'vertical_align_bottom',
+  'west', 'east', 'inbox', 'title', 'text_fields', 'image', 'smart_button',
+  'ads_click', 'video_library', 'segment', 'star'
+];


### PR DESCRIPTION
## Summary

- **Icon picker**: replaced the non-functional stub with a curated `v-icon` grid (`v-menu` + `v-list-item`, `AREA_ICON_CHOICES`) bound to `area.icon`, disabled for locked rows, tokenized.
- **Allowed collections**: when the M2A field is unrestricted, `formattedAllowedCollections` now lists every eligible collection (excludes system / folder / hidden / junction) instead of an empty picker. Restricted fields are unchanged (exact subset).

## Why not the native interface-select-icon

It renders, but it is a full-width form field whose menu teleports to `body` with version-specific markup (11.11.0 `.content.full`). In the compact AreaManager cell it shows ~2 icons wide and overflows the page, and cannot be styled cleanly (teleported → scoped `:deep` can't reach it). A custom curated grid is robust and matches the #54 design handoff.

## Test plan

- [x] `type-check`, `lint` (0 errors), `build`
- [x] Unit tests (48/48)
- [x] Live (Directus 11.11.0): AreaManager icon grid opens, picking updates the trigger + closes the menu + highlights the selection; locked rows show a static icon
- [x] Live: allowed-collections "+" lists the field's collections (restricted demo field shows its exact subset)
- [ ] Verify the unrestricted case on an M2A field without collection restriction (demo field is restricted)

Closes #64