### PR TITLE
AreaManager: lock/unlock, delete confirm, collection icons, polish

### DIFF
--- a/src/components/AreaDeleteConfirm.vue
+++ b/src/components/AreaDeleteConfirm.vue
@@ -1,0 +1,89 @@
+<template>
+  <!--
+    Slim area-removal confirmation. Structure mirrors DeleteConfirmationDialog.vue
+    (v-dialog + v-card + @esc), but this is a simple Yes/No confirm with an optional
+    orphan warning — not the block-specific unassign/delete choice. Focus
+    capture/restore is owned by the parent (AreaManager), because only the parent
+    knows that confirming removes the trigger row from the DOM.
+  -->
+  <v-dialog
+    :model-value="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
+    @esc="handleCancel"
+  >
+    <v-card>
+      <v-card-title class="confirm-title">
+        <v-icon name="delete" />
+        <span>Remove "{{ areaLabel }}"?</span>
+      </v-card-title>
+
+      <v-card-text>
+        <p class="confirm-text">
+          This removes the area from the layout. You can add it again later with "Add area".
+        </p>
+        <v-notice v-if="blockCount > 0" type="warning" class="orphan-warning">
+          This area contains {{ blockCount }} {{ blockCount === 1 ? 'block' : 'blocks' }} —
+          they will become orphaned when you save.
+        </v-notice>
+      </v-card-text>
+
+      <v-card-actions>
+        <v-button secondary @click="handleCancel">Cancel</v-button>
+        <v-button kind="danger" @click="handleConfirm">
+          <v-icon class="cta-icon" name="delete" small />
+          Remove area
+        </v-button>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  modelValue: boolean;
+  areaLabel?: string;
+  blockCount?: number;
+}
+
+withDefaults(defineProps<Props>(), {
+  areaLabel: 'this area',
+  blockCount: 0
+});
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean];
+  'confirm': [];
+  'cancel': [];
+}>();
+
+function handleConfirm() {
+  emit('confirm');
+  emit('update:modelValue', false);
+}
+
+function handleCancel() {
+  emit('cancel');
+  emit('update:modelValue', false);
+}
+</script>
+
+<style lang="scss" scoped>
+.confirm-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.confirm-text {
+  color: var(--theme--foreground);
+  margin: 0;
+}
+
+.orphan-warning {
+  margin-top: 12px;
+}
+
+.cta-icon {
+  margin-right: 4px;
+}
+</style>

--- a/src/components/AreaManager.vue
+++ b/src/components/AreaManager.vue
@@ -317,7 +317,7 @@
                       x-small
                       secondary
                       class="danger"
-                      @click="removeArea(index)"
+                      @click="removeArea(area)"
                     >
                       <v-icon name="delete" />
                     </v-button>
@@ -459,28 +459,36 @@ function toggleLock(area: AreaConfig, index: number) {
 
 // --- Area removal with confirmation ----------------------------------------
 // A single shared confirm dialog (rendered once, outside the row loop) is driven
-// by `areaPendingRemoval` (the row index) — never one dialog per row. `removeArea`
-// only opens the dialog; `confirmRemoveArea` performs the splice.
-const areaPendingRemoval = ref<number | null>(null);
+// by `areaPendingRemoval` (the area id, NOT an index — so a reorder can never
+// retarget the wrong row) — never one dialog per row. `removeArea` only opens the
+// dialog; `confirmRemoveArea` resolves the id and performs the splice.
+const areaPendingRemoval = ref<string | null>(null);
 const removeTrigger = ref<HTMLElement | null>(null);
 
 const pendingArea = computed<AreaConfig | null>(() =>
-  areaPendingRemoval.value === null ? null : (localAreas.value[areaPendingRemoval.value] ?? null)
+  areaPendingRemoval.value === null
+    ? null
+    : (localAreas.value.find(a => a.id === areaPendingRemoval.value) ?? null)
 );
 const pendingBlockCount = computed<number>(() =>
   pendingArea.value ? (props.blockCountsByArea?.[pendingArea.value.id] ?? 0) : 0
 );
 
-function removeArea(index: number) {
+function removeArea(area: AreaConfig) {
   // Remember the trigger so focus can return to it if the user cancels.
   const el = document.activeElement;
   removeTrigger.value = el instanceof HTMLElement ? el : null;
-  areaPendingRemoval.value = index;
+  areaPendingRemoval.value = area.id;
 }
 
 function confirmRemoveArea() {
-  const index = areaPendingRemoval.value;
-  if (index === null) return;
+  const id = areaPendingRemoval.value;
+  if (id === null) return;
+  const index = localAreas.value.findIndex(a => a.id === id);
+  if (index === -1) {
+    areaPendingRemoval.value = null;
+    return;
+  }
   const area = localAreas.value[index];
   localAreas.value.splice(index, 1);
   validateAreas();
@@ -738,7 +746,10 @@ function save() {
   validateAreas();
 
   if (!hasErrors.value) {
-    emit('update:areas', [...localAreas.value]);
+    // The orphaned area is system-managed (injected at runtime from orphaned
+    // blocks); never persist it into the field config, or it lingers as a phantom
+    // entry once the orphaned blocks are gone.
+    emit('update:areas', localAreas.value.filter(a => a.id !== ORPHANED_AREA_ID));
     emit('close');
   }
 }

--- a/src/components/AreaManager.vue
+++ b/src/components/AreaManager.vue
@@ -1,7 +1,16 @@
 <template>
-  <div class="area-manager">
+  <div ref="rootEl" class="area-manager">
     <div class="manager-content">
       <div class="area-section">
+        <!-- "Add area" lives in the drawer body (CI: the drawer header keeps a
+             single native round Save action). -->
+        <div class="area-section-toolbar">
+          <v-button secondary small @click="addArea">
+            <v-icon name="add" left />
+            Add area
+          </v-button>
+        </div>
+
         <div v-if="localAreas.length > 0" class="areas-table-wrapper">
           <table class="areas-table">
             <thead>
@@ -12,8 +21,8 @@
                 <th>ID</th>
                 <th style="width: 150px">Width</th>
                 <th style="width: 100px">Max Items</th>
-                <th>Allowed Collections</th>
-                <th style="width: 60px">Actions</th>
+                <th>Collections</th>
+                <th style="width: 90px">Actions</th>
               </tr>
             </thead>
             <draggable
@@ -229,20 +238,24 @@
                   <!-- Allowed Collections -->
                   <td class="collections-cell">
                     <div class="collections-list">
-                      <div v-if="area.allowedTypes && area.allowedTypes.length > 0" class="collection-tags">
-                        <v-chip
-                          v-for="collection in area.allowedTypes"
-                          :key="collection"
-                          small
-                          close
-                          :disabled="area.locked"
-                          @close="!area.locked && removeCollection(area, collection)"
-                        >
-                          {{ getCollectionLabel(collection) }}
+                      <div class="collection-tags">
+                        <template v-if="area.allowedTypes && area.allowedTypes.length > 0">
+                          <v-chip
+                            v-for="collection in area.allowedTypes"
+                            :key="collection"
+                            small
+                            close
+                            :disabled="area.locked"
+                            @close="!area.locked && removeCollection(area, collection)"
+                          >
+                            {{ getCollectionLabel(collection) }}
+                          </v-chip>
+                        </template>
+                        <!-- No restriction = a non-removable "All collections" chip,
+                             so empty and filled cells stay visually consistent. -->
+                        <v-chip v-else small class="all-collections-chip">
+                          All collections
                         </v-chip>
-                      </div>
-                      <div v-else class="no-collections">
-                        All collections
                       </div>
                       <v-menu
                         v-if="!area.locked && getAvailableCollectionsForArea(area).length > 0"
@@ -253,6 +266,7 @@
                           <v-button
                             x-small
                             icon
+                            secondary
                             v-btn-aria="{ 'aria-label': 'Add allowed collection', 'aria-haspopup': 'menu', 'aria-expanded': active }"
                             @click="toggle"
                           >
@@ -266,6 +280,9 @@
                             clickable
                             @click="addCollection(area, collection.value)"
                           >
+                            <v-list-item-icon>
+                              <v-icon :name="collection.icon || 'box'" small />
+                            </v-list-item-icon>
                             <v-list-item-content>{{ collection.text }}</v-list-item-content>
                           </v-list-item>
                         </v-list>
@@ -274,6 +291,24 @@
                   </td>
 
                   <td class="actions-cell">
+                    <!-- Lock/unlock toggle: ALWAYS rendered so a locked area can be
+                         unlocked again. The orphaned area is system-locked and not
+                         toggleable (disabled). -->
+                    <v-button
+                      v-tooltip="isOrphaned(area) ? 'This area cannot be unlocked' : (area.locked ? 'Unlock area' : 'Lock area')"
+                      v-btn-aria="{
+                        'aria-label': area.locked ? 'Unlock area' : 'Lock area',
+                        'aria-pressed': !!area.locked,
+                        'aria-disabled': isOrphaned(area) || undefined
+                      }"
+                      icon
+                      x-small
+                      secondary
+                      :disabled="isOrphaned(area)"
+                      @click="toggleLock(area, index)"
+                    >
+                      <v-icon :name="area.locked ? 'lock' : 'lock_open'" />
+                    </v-button>
                     <v-button
                       v-if="!area.locked"
                       v-tooltip="'Remove area'"
@@ -286,13 +321,6 @@
                     >
                       <v-icon name="delete" />
                     </v-button>
-                    <v-icon
-                      v-else
-                      v-tooltip="'This area cannot be removed'"
-                      name="lock"
-                      small
-                      aria-label="locked"
-                    />
                   </td>
                 </tr>
               </template>
@@ -306,14 +334,24 @@
           message='No areas defined yet — use "Add area" to create one.'
         />
 
-        <!--
-          Explains the locked-row treatment (lock icon + disabled inline edit).
-          Shown only when at least one area is field-configured/locked.
-        -->
+        <!-- Communicates the one non-obvious lock effect: locking also freezes the
+             area's blocks in the layout views. The row-level freeze (static fields,
+             lock icon) is already visible, so it isn't repeated here. -->
         <p v-if="hasLockedAreas" class="locked-hint">
           <v-icon name="info" small />
-          Locked areas are defined in the field configuration and can't be edited here.
+          Locking an area also freezes its blocks — they can't be added, moved or reordered.
         </p>
+
+        <!-- Single shared removal confirm (rendered once, outside the row loop):
+             one instance driven by areaPendingRemoval, never one per row. -->
+        <AreaDeleteConfirm
+          :model-value="areaPendingRemoval !== null"
+          :area-label="pendingArea?.label || pendingArea?.id || ''"
+          :block-count="pendingBlockCount"
+          @update:model-value="(open) => { if (!open) cancelRemove(); }"
+          @confirm="confirmRemoveArea"
+          @cancel="cancelRemove"
+        />
       </div>
     </div>
   </div>
@@ -323,16 +361,21 @@
 import { ref, computed, onMounted, nextTick } from 'vue';
 import { vBtnAria } from '../directives/btnAria';
 import EmptyState from './EmptyState.vue';
+import AreaDeleteConfirm from './AreaDeleteConfirm.vue';
 import { cloneDeep } from 'lodash-es';
 import draggable from 'vuedraggable';
-import type { AreaConfig } from '../types';
-import { WIDTH_OPTIONS, AREA_ICON_CHOICES } from '../utils/constants';
+import type { AreaConfig, CollectionOption } from '../types';
+import { WIDTH_OPTIONS, AREA_ICON_CHOICES, ORPHANED_AREA_ID } from '../utils/constants';
 import { validateAreaConfig, sanitizeAreaId } from '../utils/validators';
+import { logger } from '../utils/logger';
 
 // Props
 interface Props {
   areas: AreaConfig[];
-  availableCollections?: Array<{ text: string; value: string }>;
+  availableCollections?: CollectionOption[];
+  // Map areaId -> block count, used for the removal orphan warning. Optional with
+  // a safe default so the manager renders even if a parent omits it.
+  blockCountsByArea?: Record<string, number>;
 }
 
 const props = defineProps<Props>();
@@ -357,6 +400,8 @@ type TextEditField = Exclude<EditableField, 'width'>;
 // from `areas` to avoid a prop/ref name collision that made the template binding
 // ambiguous).
 const localAreas = ref<AreaConfig[]>([]);
+// Root element, used as a focus fallback after a removed row's trigger is gone.
+const rootEl = ref<HTMLElement | null>(null);
 const errors = ref<Record<string, string[]>>({});
 // Index + field are tracked separately (not as a composite "i-field" string) so
 // the Tab-advance logic never has to parse a key.
@@ -396,9 +441,82 @@ function addArea() {
   validateAreas();
 }
 
+function isOrphaned(area: AreaConfig): boolean {
+  return area.id === ORPHANED_AREA_ID;
+}
+
+// Toggle an area's lock from the editor. NOTE: locking freezes the WHOLE area —
+// the row here AND its blocks in the layout views (add/move/drag all key off
+// `locked`). The orphaned area is system-locked and never toggleable. If the row
+// being locked is mid inline-edit, cancel that edit first so no commit lands on a
+// now-locked area.
+function toggleLock(area: AreaConfig, index: number) {
+  if (isOrphaned(area)) return;
+  if (!area.locked && editingArea.value === index) cancelEdit();
+  area.locked = !area.locked;
+  validateAreas();
+}
+
+// --- Area removal with confirmation ----------------------------------------
+// A single shared confirm dialog (rendered once, outside the row loop) is driven
+// by `areaPendingRemoval` (the row index) — never one dialog per row. `removeArea`
+// only opens the dialog; `confirmRemoveArea` performs the splice.
+const areaPendingRemoval = ref<number | null>(null);
+const removeTrigger = ref<HTMLElement | null>(null);
+
+const pendingArea = computed<AreaConfig | null>(() =>
+  areaPendingRemoval.value === null ? null : (localAreas.value[areaPendingRemoval.value] ?? null)
+);
+const pendingBlockCount = computed<number>(() =>
+  pendingArea.value ? (props.blockCountsByArea?.[pendingArea.value.id] ?? 0) : 0
+);
+
 function removeArea(index: number) {
+  // Remember the trigger so focus can return to it if the user cancels.
+  const el = document.activeElement;
+  removeTrigger.value = el instanceof HTMLElement ? el : null;
+  areaPendingRemoval.value = index;
+}
+
+function confirmRemoveArea() {
+  const index = areaPendingRemoval.value;
+  if (index === null) return;
+  const area = localAreas.value[index];
   localAreas.value.splice(index, 1);
   validateAreas();
+  logger.log('Area removed', {
+    areaId: area?.id,
+    label: area?.label,
+    blockCount: area ? (props.blockCountsByArea?.[area.id] ?? 0) : 0
+  });
+  areaPendingRemoval.value = null;
+  // The trigger button was removed with its row → focus a stable fallback.
+  restoreFocusAfterRemove(true);
+}
+
+function cancelRemove() {
+  areaPendingRemoval.value = null;
+  restoreFocusAfterRemove(false);
+}
+
+// Return focus after the dialog closes. On cancel the trigger still exists; on
+// confirm it was removed with its row, so fall back to a stable anchor. The
+// `document.contains` guard ensures focus never lands on a detached node.
+function restoreFocusAfterRemove(triggerRemoved: boolean) {
+  const el = removeTrigger.value;
+  removeTrigger.value = null;
+  // On cancel the trigger still exists → restore to it on the next tick.
+  if (!triggerRemoved && el && document.contains(el)) {
+    nextTick(() => { if (document.contains(el)) el.focus(); });
+    return;
+  }
+  // On confirm the trigger row (and its focused button) is removed; the v-dialog
+  // resets focus to <body> as it tears down, AFTER a single nextTick. Defer one
+  // animation frame past that before moving focus to a stable fallback anchor.
+  nextTick(() => requestAnimationFrame(() => {
+    (rootEl.value?.querySelector<HTMLElement>('.actions-cell button')
+      ?? rootEl.value?.querySelector<HTMLElement>('button'))?.focus();
+  }));
 }
 
 // Picks an area's icon from the curated grid. Like the inline-edit mutators, this
@@ -577,7 +695,7 @@ function getCollectionLabel(collection: string): string {
   return found?.text || collection;
 }
 
-function getAvailableCollectionsForArea(area: AreaConfig): Array<{ text: string; value: string }> {
+function getAvailableCollectionsForArea(area: AreaConfig): CollectionOption[] {
   if (!props.availableCollections) return [];
 
   const usedCollections = area.allowedTypes || [];
@@ -649,6 +767,11 @@ defineExpose({
   gap: 32px;
 }
 
+.area-section-toolbar {
+  display: flex;
+  margin-bottom: 16px;
+}
+
 .areas-table-wrapper {
   overflow-x: auto;
   border: var(--theme--border-width) solid var(--theme--border-color-subdued);
@@ -660,17 +783,22 @@ defineExpose({
   width: 100%;
   border-collapse: collapse;
 
-  /* Sentence-case, subdued, hairline header (tokenized — matches ListView #51).
-     The header is not sticky here, so it carries no fill and inherits the
-     wrapper's --theme--background (screenshots/05). */
+  /* Subdued header with a tokenized fill — mirrors the redesigned ListView table
+     header (#51, issue #73). Not sticky here: the table's vertical scroll lives on
+     .manager-content, not the table, so a sticky thead wouldn't track it. Keeps
+     --theme--border-width (not a hardcoded 1px). */
   thead {
     th {
       padding: 12px;
       text-align: left;
       font-weight: 600;
       font-size: 12px;
-      color: var(--theme--foreground-subdued);
-      border-bottom: var(--theme--border-width) solid var(--theme--border-color-subdued);
+      white-space: nowrap;
+      /* Normal foreground (not -subdued) for readable contrast on the subdued
+         header fill — subdued-on-subdued was too light. */
+      color: var(--theme--foreground);
+      background: var(--theme--background-subdued);
+      border-bottom: var(--theme--border-width) solid var(--theme--border-color);
     }
   }
 
@@ -705,7 +833,12 @@ defineExpose({
 
       &.actions-cell {
         text-align: center;
-        width: 60px;
+        white-space: nowrap;
+        width: 90px;
+
+        .v-button {
+          margin: 0 1px;
+        }
       }
 
       &.collections-cell {
@@ -831,28 +964,42 @@ defineExpose({
   }
 }
 
+/* Chips on top, the add "+" below — consistent for both the empty state (a
+   non-removable "All collections" chip) and explicitly selected collections. */
 .collections-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
   align-items: flex-start;
+  gap: 6px;
 
   .collection-tags {
     display: flex;
     flex-wrap: wrap;
     gap: 4px;
   }
+}
 
-  .no-collections {
-    color: var(--theme--foreground-subdued);
-    font-style: italic;
-    font-size: 13px;
-    padding: 4px 0;
-  }
+/* The "no restriction" placeholder: same chip shape as a real collection, but
+   italic + subdued so it reads as the default rather than an explicit pick. */
+.all-collections-chip {
+  font-style: italic;
+  --v-chip-color: var(--theme--foreground-subdued);
+}
 
-  .v-button {
-    margin-top: 4px;
-  }
+/* The sibling expandable-blocks extension leaks a global
+   `.close-outline { background: red !important }` (see project memory
+   extension-css-global-collision) that turns the native v-chip close button into
+   an ugly solid-red circle. Restore the native subtle treatment for our
+   collection chips — scoped + !important to beat the leak. */
+.collections-cell :deep(.v-chip .close-outline) {
+  background: transparent !important;
+  border-left: none !important;
+  border-radius: 50% !important;
+  right: auto !important;
+}
+
+.collections-cell :deep(.v-chip .close-outline:hover) {
+  background: var(--theme--danger-background) !important;
 }
 
 .locked-hint {

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -71,7 +71,7 @@
               :area="area"
               :compact="options.compactMode"
               :permissions="permissions"
-              :draggable="options.enableDragDrop && (!area.locked || area.id === 'orphaned')"
+              :draggable="options.enableDragDrop && (!area.locked || area.id === ORPHANED_AREA_ID)"
               :grabbed="isBlockGrabbed(block.id)"
               @edit="$emit('update-block', { blockId: block.id })"
               @remove="$emit('remove-block', block.id)"
@@ -138,6 +138,7 @@ import type {
 import BlockItemComponent from './BlockItem.vue';
 import EmptyState from './EmptyState.vue';
 import { createDragImage, getBlockTitle } from '../utils/blockHelpers';
+import { ORPHANED_AREA_ID } from '../utils/constants';
 import { useKeyboardDnd } from '../composables/useKeyboardDnd';
 
 // Props
@@ -328,7 +329,7 @@ function handleBlockStatusUpdate(block: BlockItem, newStatus: string) {
 // Drag & Drop
 function handleDragStart(event: DragEvent, block: BlockItem, area: AreaConfig) {
   // Allow dragging from orphaned area even if it's locked
-  if (!props.options.enableDragDrop || (area.locked && area.id !== 'orphaned')) {
+  if (!props.options.enableDragDrop || (area.locked && area.id !== ORPHANED_AREA_ID)) {
     event.preventDefault();
     return;
   }
@@ -382,7 +383,7 @@ function handleDragOver(event: DragEvent, area: AreaConfig) {
   const areaElement = event.currentTarget as HTMLElement;
   
   // Don't allow dropping into orphaned area
-  if (!draggedBlock.value || area.id === 'orphaned') {
+  if (!draggedBlock.value || area.id === ORPHANED_AREA_ID) {
     event.preventDefault();
     event.dataTransfer!.dropEffect = 'none';
     areaElement.classList.add('drag-not-allowed');
@@ -392,7 +393,7 @@ function handleDragOver(event: DragEvent, area: AreaConfig) {
   }
   
   // Allow dropping into other locked areas if they aren't orphaned
-  if (area.locked && area.id !== 'orphaned') {
+  if (area.locked && area.id !== ORPHANED_AREA_ID) {
     event.preventDefault();
     event.dataTransfer!.dropEffect = 'none';
     areaElement.classList.add('drag-not-allowed');
@@ -441,12 +442,12 @@ function handleDrop(event: DragEvent, targetArea: AreaConfig) {
   event.preventDefault();
   
   // Don't allow dropping into orphaned area
-  if (!draggedBlock.value || !draggedFromArea.value || targetArea.id === 'orphaned') {
+  if (!draggedBlock.value || !draggedFromArea.value || targetArea.id === ORPHANED_AREA_ID) {
     return;
   }
   
   // Allow dropping into other areas if they aren't orphaned
-  if (targetArea.locked && targetArea.id !== 'orphaned') {
+  if (targetArea.locked && targetArea.id !== ORPHANED_AREA_ID) {
     return;
   }
 
@@ -479,7 +480,7 @@ function handleDrop(event: DragEvent, targetArea: AreaConfig) {
 
 function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
   // Never allow dropping into orphaned area
-  if (area.id === 'orphaned') {
+  if (area.id === ORPHANED_AREA_ID) {
     return false;
   }
 

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -35,7 +35,7 @@
         :class="{
           active: selectedArea === area.id,
           'has-blocks': hasBlocks(area.id),
-          'orphaned': area.id === 'orphaned'
+          'orphaned': area.id === ORPHANED_AREA_ID
         }"
         :data-area-id="area.id"
         @click="selectArea(area.id)"
@@ -46,7 +46,7 @@
       >
         <v-icon v-if="area.icon" :name="area.icon" small />
         <span>{{ area.label }}</span>
-        <v-chip v-if="getAreaBlocks(area.id).length > 0" x-small :class="{ 'warning': area.id === 'orphaned' }">
+        <v-chip v-if="getAreaBlocks(area.id).length > 0" x-small :class="{ 'warning': area.id === ORPHANED_AREA_ID }">
           {{ getAreaBlocks(area.id).length }}
         </v-chip>
       </button>
@@ -81,7 +81,7 @@
         <table class="blocks-table" role="grid">
           <thead>
             <tr role="row">
-              <th v-if="options.enableDragDrop && (!selectedAreaConfig?.locked || selectedArea === 'orphaned')" role="columnheader" style="width: 40px"></th>
+              <th v-if="options.enableDragDrop && (!selectedAreaConfig?.locked || selectedArea === ORPHANED_AREA_ID)" role="columnheader" style="width: 40px"></th>
               <th role="columnheader" style="width: 40px"></th>
               <th role="columnheader">
                 <div class="header-with-icon">
@@ -101,7 +101,7 @@
                   <span>Status</span>
                 </div>
               </th>
-              <th v-if="selectedArea === null || selectedArea === 'orphaned'" role="columnheader" style="width: 15%">
+              <th v-if="selectedArea === null || selectedArea === ORPHANED_AREA_ID" role="columnheader" style="width: 15%">
                 <div class="header-with-icon">
                   <v-icon name="dashboard" small />
                   <span>Area</span>
@@ -123,7 +123,7 @@
               :class="{ 'kb-grabbed': kbIsGrabbed(block.id) }"
               role="row"
             >
-              <td v-if="options.enableDragDrop && (!selectedAreaConfig?.locked || selectedArea === 'orphaned')" role="gridcell" class="drag-cell">
+              <td v-if="options.enableDragDrop && (!selectedAreaConfig?.locked || selectedArea === ORPHANED_AREA_ID)" role="gridcell" class="drag-cell">
                 <div
                   class="drag-handle"
                   role="button"
@@ -166,7 +166,7 @@
                 />
               </td>
               
-              <td v-if="selectedArea === null || selectedArea === 'orphaned'" role="gridcell" class="area-cell">
+              <td v-if="selectedArea === null || selectedArea === ORPHANED_AREA_ID" role="gridcell" class="area-cell">
                 <v-chip 
                   v-if="getAreaForBlock(block)"
                   small
@@ -272,7 +272,8 @@ import AddBlockDropdown from './AddBlockDropdown.vue';
 import StatusSelector from './StatusSelector.vue';
 import EmptyState from './EmptyState.vue';
 import DeleteConfirmationDialog from './DeleteConfirmationDialog.vue';
-import { createDragImage } from '../utils/blockHelpers';
+import { createDragImage, getBlockIcon } from '../utils/blockHelpers';
+import { ORPHANED_AREA_ID } from '../utils/constants';
 import { useKeyboardDnd } from '../composables/useKeyboardDnd';
 import { vBtnAria } from '../directives/btnAria';
 import type {
@@ -372,10 +373,10 @@ const selectedAreaBlocks = computed(() => {
       }
       return a.sort - b.sort;
     });
-  } else if (props.selectedArea === 'orphaned') {
+  } else if (props.selectedArea === ORPHANED_AREA_ID) {
     // Show blocks in orphaned area
     logger.log('🟣 ListView: Showing orphaned blocks');
-    return getAreaBlocks('orphaned');
+    return getAreaBlocks(ORPHANED_AREA_ID);
   } else {
     // Show blocks for specific area
     const blocks = getAreaBlocks(props.selectedArea || '');
@@ -385,19 +386,19 @@ const selectedAreaBlocks = computed(() => {
 });
 
 const orphanedBlocks = computed(() => {
-  // In the new system, orphaned blocks have area === 'orphaned'
-  return props.blocks.filter(block => block.area === 'orphaned');
+  // In the new system, orphaned blocks have area === ORPHANED_AREA_ID
+  return props.blocks.filter(block => block.area === ORPHANED_AREA_ID);
 });
 
 const hasOrphanedArea = computed(() => {
   // Check if orphaned area exists in areas list
-  return props.areas.some(a => a.id === 'orphaned');
+  return props.areas.some(a => a.id === ORPHANED_AREA_ID);
 });
 
 // Watch for when orphaned blocks become empty
 watch(orphanedBlocks, (newOrphaned, oldOrphaned) => {
   // If we're currently viewing orphaned blocks and they become empty
-  if (props.selectedArea === 'orphaned' && oldOrphaned.length > 0 && newOrphaned.length === 0) {
+  if (props.selectedArea === ORPHANED_AREA_ID && oldOrphaned.length > 0 && newOrphaned.length === 0) {
     logger.log('🟣 ListView: No more orphaned blocks, switching to first available area');
     // Switch to first visible area
     if (visibleAreas.value.length > 0) {
@@ -407,16 +408,6 @@ watch(orphanedBlocks, (newOrphaned, oldOrphaned) => {
     }
   }
 });
-
-// Collection icon mapping
-const collectionIcons: Record<string, string> = {
-  content_headline: 'title',
-  content_text: 'text_fields',
-  content_image: 'image',
-  content_video: 'videocam',
-  content_hero: 'landscape',
-  content_cta: 'ads_click'
-};
 
 // Keyboard drag & drop (KEYBOARD_AND_A11Y.md §3): the row's drag handle is the
 // grab target. ListView shows one area at a time, so onAreaChange follows the
@@ -513,10 +504,6 @@ function getAreaChipStyle(block: BlockItem) {
 function getAreaProgress(area: AreaConfig): number {
   if (!area.maxItems) return 0;
   return (getAreaBlocks(area.id).length / area.maxItems) * 100;
-}
-
-function getBlockIcon(block: BlockItem): string {
-  return collectionIcons[block.collection] || 'widgets';
 }
 
 function getBlockTitle(block: BlockItem): string {
@@ -694,7 +681,7 @@ function handleAreaDrop(event: DragEvent, targetAreaId: string) {
   logger.log('🟣 ListView: Dropping block', blockId, 'from', sourceArea, 'to', targetAreaId);
   
   // Check if this is the last orphaned block
-  const isLastOrphanedBlock = props.selectedArea === 'orphaned' && orphanedBlocks.value.length === 1;
+  const isLastOrphanedBlock = props.selectedArea === ORPHANED_AREA_ID && orphanedBlocks.value.length === 1;
   
   // Emit move event
   emit('move-block', {
@@ -715,7 +702,7 @@ function handleAreaDrop(event: DragEvent, targetAreaId: string) {
 
 function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
   // Never allow dropping into orphaned area
-  if (area.id === 'orphaned') {
+  if (area.id === ORPHANED_AREA_ID) {
     return false;
   }
   

--- a/src/composables/useKeyboardDnd.ts
+++ b/src/composables/useKeyboardDnd.ts
@@ -1,6 +1,7 @@
 import { ref, nextTick, type Ref } from 'vue';
 import { logger } from '../utils/logger';
 import type { BlockItem, BlockId, AreaConfig } from '../types';
+import { ORPHANED_AREA_ID } from '../utils/constants';
 
 /**
  * Keyboard equivalent of the pointer drag & drop (KEYBOARD_AND_A11Y.md §3).
@@ -89,7 +90,7 @@ export function useKeyboardDnd(deps: KeyboardDndDeps) {
     /* Mirror the pointer rule: locked areas can't be dragged out of, except the
        orphaned area (which is itself never a drop target but its blocks may be
        rescued out of it). */
-    if (source?.locked && source.id !== 'orphaned') return false;
+    if (source?.locked && source.id !== ORPHANED_AREA_ID) return false;
     return true;
   }
 
@@ -127,7 +128,7 @@ export function useKeyboardDnd(deps: KeyboardDndDeps) {
   function moveAcross(block: BlockItem, direction: -1 | 1): void {
     /* Only real areas are traversal targets; the orphaned area is never a drop
        target, so exclude it from the left/right order. */
-    const order = deps.areas.value.filter((a) => a.id !== 'orphaned');
+    const order = deps.areas.value.filter((a) => a.id !== ORPHANED_AREA_ID);
     const curIdx = order.findIndex((a) => a.id === block.area);
     let k = curIdx + direction;
     let skipped = false;

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -304,24 +304,24 @@
           ref="areaManagerRef"
           :areas="allConfiguredAreas"
           :available-collections="formattedAllowedCollections"
+          :block-counts-by-area="blockCountsByArea"
           @update:areas="handleAreasUpdate"
           @close="showAreaManager = false"
         />
         
         <template #actions>
-          <!-- Directus's v-drawer renders only the LAST child of its actions
-               slot (.action-buttons > :not(:last-child) { display: none }), so
-               wrap our buttons in one element to show both. The header's X
-               (top-left) is the native cancel/discard. -->
-          <div class="drawer-actions">
-            <v-button v-tooltip="'Add area'" secondary small @click="addAreaInManager">
-              <v-icon name="add" left />
-              Add area
-            </v-button>
-            <v-button @click="saveAreas">
-              Save Areas
-            </v-button>
-          </div>
+          <!-- Native Directus drawer pattern: a single round primary action
+               (Save). The header X (top-left) is the native cancel/discard, and
+               "Add area" lives in the drawer body where additive actions belong. -->
+          <v-button
+            v-tooltip="'Save areas'"
+            v-btn-aria="{ 'aria-label': 'Save areas' }"
+            rounded
+            icon
+            @click="saveAreas"
+          >
+            <v-icon name="check" />
+          </v-button>
         </template>
       </v-drawer>
     </div>
@@ -338,8 +338,9 @@ import { useAutoSetup } from './composables/useAutoSetup';
 import { useBlocks } from './composables/useBlocks';
 import { usePermissions } from './composables/usePermissions';
 import { useBlockPermissions } from './composables/useBlockPermissions';
-import { DEFAULT_OPTIONS, DEFAULT_AREA_CONFIG } from './utils/constants';
+import { DEFAULT_OPTIONS, DEFAULT_AREA_CONFIG, ORPHANED_AREA_ID } from './utils/constants';
 import { normalizeAreaIds, isTempId, formatCollectionName } from './utils/helpers';
+import { getCollectionIcon } from './utils/blockHelpers';
 import { cloneDeep } from 'lodash-es';
 import { CUSTOM_AREAS, USE_CUSTOM_AREAS } from './config/areas';
 import type {
@@ -347,7 +348,8 @@ import type {
   JunctionInfo,
   BlockItem,
   BlockId,
-  AreaConfig
+  AreaConfig,
+  CollectionOption
 } from './types';
 
 // Import components (we'll create these next)
@@ -658,12 +660,12 @@ const computedAreas = computed<AreaConfig[]>(() => {
   areas = normalizeAreaIds(areas, options.value.defaultArea || 'main');
 
   // Only add orphaned area if there are orphaned blocks
-  const hasOrphanedBlocks = blocks.value.some(b => b.area === 'orphaned');
-  const hasOrphanedArea = areas.some(a => a.id === 'orphaned');
+  const hasOrphanedBlocks = blocks.value.some(b => b.area === ORPHANED_AREA_ID);
+  const hasOrphanedArea = areas.some(a => a.id === ORPHANED_AREA_ID);
   
   if (hasOrphanedBlocks && !hasOrphanedArea) {
     areas.push({
-      id: 'orphaned',
+      id: ORPHANED_AREA_ID,
       label: 'Orphaned Blocks',
       icon: 'help_outline',
       width: 100,
@@ -671,7 +673,7 @@ const computedAreas = computed<AreaConfig[]>(() => {
     });
   } else if (!hasOrphanedBlocks && hasOrphanedArea) {
     // Remove orphaned area if no orphaned blocks exist
-    areas = areas.filter(a => a.id !== 'orphaned');
+    areas = areas.filter(a => a.id !== ORPHANED_AREA_ID);
   }
   
   return areas;
@@ -729,6 +731,16 @@ function getBlocksForArea(areaId: string): BlockItem[] {
   return blocks.value.filter(b => b.area === areaId);
 }
 
+// Per-area block counts for the AreaManager delete-confirmation orphan warning.
+// One O(n) reduce over blocks, exposed as a map areaId -> count.
+const blockCountsByArea = computed<Record<string, number>>(() => {
+  const counts: Record<string, number> = {};
+  for (const block of blocks.value) {
+    counts[block.area] = (counts[block.area] || 0) + 1;
+  }
+  return counts;
+});
+
 // Get allowed collections for M2A
 const allowedCollections = computed(() => {
   // First check if user has selected specific collections in interface options
@@ -745,12 +757,15 @@ const allowedCollections = computed(() => {
   return null;
 });
 
-// Build a { text, value } option for the AreaManager collection picker, reusing
-// the Directus collection display name (falls back to a prettified key).
-function formatCollectionOption(collectionName: string): { text: string; value: string } {
+// Build a CollectionOption for the AreaManager collection picker, reusing the
+// Directus collection display name (falls back to a prettified key) and its
+// configured icon (falls back to the shared collection-icon helper).
+function formatCollectionOption(collectionName: string): CollectionOption {
+  const collection = collectionsStore.getCollection(collectionName);
   return {
-    text: collectionsStore.getCollection(collectionName)?.name || formatCollectionName(collectionName),
-    value: collectionName
+    text: collection?.name || formatCollectionName(collectionName),
+    value: collectionName,
+    icon: collection?.icon || getCollectionIcon(collectionName)
   };
 }
 
@@ -1206,20 +1221,6 @@ function getTranslatedFieldValue(item: any, field: string): any {
 
 function isFieldTranslatable(field: string): boolean {
   return itemSelector?.isFieldTranslatable(field) || false;
-}
-
-function getCollectionIcon(collection: string): string {
-  const collectionInfo: Record<string, any> = {
-    content_headline: { icon: 'title' },
-    content_text: { icon: 'text_fields' },
-    content_image: { icon: 'image' },
-    content_video: { icon: 'videocam' },
-    content_cta: { icon: 'ads_click' },
-    content_button: { icon: 'smart_button' },
-    content_wysiwig: { icon: 'edit_note' },
-    content_block: { icon: 'widgets' }
-  };
-  return collectionInfo[collection]?.icon || 'widgets';
 }
 
 async function handleItemSelectorLinked(items: any[]) {
@@ -1699,7 +1700,7 @@ async function handleAreasUpdate(updatedAreas: AreaConfig[]) {
         // write — keeps the form in a single consistent, discardable state).
         const blockIndex = blocks.value.findIndex(b => b.id === block.id);
         if (blockIndex !== -1) {
-          blocks.value[blockIndex].area = 'orphaned';
+          blocks.value[blockIndex].area = ORPHANED_AREA_ID;
           markBlockDirty(block.id, true);
           logger.log(`Interface: Block ${block.id} staged for orphaning`);
         }
@@ -1764,12 +1765,6 @@ async function handleAreasUpdate(updatedAreas: AreaConfig[]) {
 }
 
 // Save areas from area manager
-// Triggers a new area row from the area-manager drawer header (the body
-// "Add area" button moved into the drawer #actions slot in #55).
-function addAreaInManager() {
-  areaManagerRef.value?.addArea();
-}
-
 function saveAreas() {
   if (areaManagerRef.value) {
     areaManagerRef.value.save();
@@ -1966,12 +1961,15 @@ watch(() => props.value, () => {
   min-height: 400px;
 }
 
-/* Wrapper so multiple drawer header actions survive Directus's
-   .action-buttons > :not(:last-child) { display: none } rule. */
-.drawer-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
+</style>
 
+<!-- Unscoped on purpose: the v-drawer panel is teleported (no component scope id)
+     and Directus doesn't forward a class onto the panel. Target only OUR drawer
+     via :has(.area-manager) — the panel that contains the AreaManager — so no
+     other Directus drawer is affected. It hosts a wide table, hence a modest bump
+     beyond the native 856px. -->
+<style lang="scss">
+.v-drawer:has(.area-manager) {
+  max-width: 1040px !important;
+}
 </style>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -110,3 +110,14 @@ export interface M2AFieldInfo {
   areaField?: string;
   sortField?: string;
 }
+
+/**
+ * A selectable collection option for the AreaManager "Allowed Collections" picker.
+ * `icon` is the collection's configured Directus icon (optional — the menu falls
+ * back to a generic icon at render time when absent).
+ */
+export interface CollectionOption {
+  text: string;
+  value: string;
+  icon?: string;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -36,6 +36,11 @@ export const DRAG_ANIMATION_DURATION = 200;
 export const MAX_AREA_ID_LENGTH = 64;
 export const MAX_AREA_LABEL_LENGTH = 255;
 
+// The special, system-managed area that collects blocks whose area no longer
+// exists. It is injected/removed automatically (interface.vue computedAreas) and
+// is always locked — never user-creatable, -editable, -removable or -unlockable.
+export const ORPHANED_AREA_ID = 'orphaned';
+
 // Status options for blocks
 export const STATUS_OPTIONS = [
   { text: 'Published', value: 'published' },


### PR DESCRIPTION
## Summary

Implements #73 — AreaManager editor improvements:

- **Lock/unlock** toggle per area (reuses `area.locked`; the orphaned area stays system-locked). Locking also freezes the area's blocks — communicated in the UI.
- **Delete confirmation** dialog (`AreaDeleteConfirm.vue`) with an orphan-blocks warning; one shared instance; focus restored after removal.
- **Collection icons** in the per-area "Allowed Collections" picker.
- **Table header** polished (readable tokenized fill, single-line headers).

### Folded in (same surface)

- Drawer: native single round **Save** action in the header; **Add area** moved into the drawer body; drawer widened to 1040px (scoped via `:has(.area-manager)`, no app-wide effect).
- Collections cell: consistent chips incl. a non-removable **All collections** chip; subtle add button; an override for the red chip close-button that the sibling extension leaks globally.
- DRY: `ORPHANED_AREA_ID` constant, shared `CollectionOption` type, single collection-icon source (removed two stale duplicate maps).

## Test plan

- [x] `type-check`, `lint` (0 errors), `build`
- [x] Unit tests (48/48)
- [x] Live (Directus 11.11.0, `layout_demo/1`): lock + unlock; delete-confirm cancel / Esc / confirm + orphan warning + focus restore; collection icons; header readability + no wrap; subtle "+"; drawer width 1040px; body "Add area" adds a row; ListView/GridView render after the orphaned-constant refactor

Closes #73
