### PR TITLE
feat: Full Width interface option for the block editor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -299,6 +299,22 @@ export default defineInterface({
       }
     },
     {
+      field: 'fullWidth',
+      name: 'Full Width',
+      type: 'boolean',
+      meta: {
+        width: 'half',
+        interface: 'boolean',
+        options: {
+          label: 'Render the editor across the full form width'
+        },
+        note: 'Breaks the interface out of the form column to use the full available width'
+      },
+      schema: {
+        default_value: false
+      }
+    },
+    {
       field: 'enableAreaManagement',
       name: 'Enable Area Management',
       type: 'boolean',

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -608,6 +608,9 @@ onUnmounted(() => {
   toolbarObserver?.disconnect();
   toolbarObserver = null;
   document.documentElement.style.removeProperty('--lb-toolbar-height');
+  // Revert the full-width breakout (if any) so we never leave an inline override
+  // on a Directus-owned `.field` after the interface is gone.
+  applyFullWidthBreakout(false);
 });
 
 // Full-width breakout (options.fullWidth): the interface normally renders inside
@@ -628,10 +631,12 @@ function applyFullWidthBreakout(enabled: boolean) {
   // element changed across a re-render) so we never leave an orphaned override.
   if (breakoutField) {
     breakoutField.style.removeProperty('grid-column');
-    breakoutField.style.removeProperty('margin-inline');
     breakoutField = null;
   }
   if (!enabled) return;
+  // Relies on Directus' form-field markup: the interface is wrapped in a `.field`.
+  // If it is absent (e.g. the interface is used outside a form), we simply no-op —
+  // no breakout, no error.
   const field = rootEl.value?.closest('.field') as HTMLElement | null;
   if (!field) return;
   breakoutField = field;
@@ -649,8 +654,6 @@ watch(
   (enabled) => { nextTick(() => applyFullWidthBreakout(!!enabled)); },
   { immediate: true },
 );
-
-onUnmounted(() => applyFullWidthBreakout(false));
 
 // Computed property for current collection fields
 const editingCollectionFields = computed(() => {

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="layout-blocks-interface">
+  <div ref="rootEl" class="layout-blocks-interface">
     <!-- Loading State -->
     <div v-if="loading" class="layout-blocks-loading">
       <v-progress-circular indeterminate />
@@ -609,6 +609,48 @@ onUnmounted(() => {
   toolbarObserver = null;
   document.documentElement.style.removeProperty('--lb-toolbar-height');
 });
+
+// Full-width breakout (options.fullWidth): the interface normally renders inside
+// the Directus form grid cell, which caps content width (e.g. the 380px columns
+// of a `with-fill` form). When enabled, span the hosting `.field` across the whole
+// form grid (`grid-column: 1 / -1`) so the editor uses the full available width —
+// independent of the form's fill mode or the field's half/full width. The form's
+// standard horizontal padding is intentionally KEPT (we do not break out of it),
+// so the editor still has the normal left/right breathing room instead of sticking
+// to the edges. Applied as an inline style on the ancestor `.field` (scoped styles
+// cannot reach an ancestor) and fully reverted when the option is off or on unmount,
+// so nothing leaks into the app globally.
+const rootEl = ref<HTMLElement | null>(null);
+let breakoutField: HTMLElement | null = null;
+
+function applyFullWidthBreakout(enabled: boolean) {
+  // Always clear a previously-styled field first (option toggled off, or the host
+  // element changed across a re-render) so we never leave an orphaned override.
+  if (breakoutField) {
+    breakoutField.style.removeProperty('grid-column');
+    breakoutField.style.removeProperty('margin-inline');
+    breakoutField = null;
+  }
+  if (!enabled) return;
+  const field = rootEl.value?.closest('.field') as HTMLElement | null;
+  if (!field) return;
+  breakoutField = field;
+  // Span the full form grid (defeats the `with-fill` 380px column cap) while
+  // staying inside the form's standard horizontal padding — full width, but with
+  // the normal left/right breathing room preserved.
+  field.style.setProperty('grid-column', '1 / -1');
+}
+
+// `immediate` covers the initial render; the watch also re-applies when the option
+// resolves late (field meta can load after mount) or is toggled. nextTick ensures
+// the root element (and thus its `.field` ancestor) exists before we query it.
+watch(
+  () => options.value.fullWidth,
+  (enabled) => { nextTick(() => applyFullWidthBreakout(!!enabled)); },
+  { immediate: true },
+);
+
+onUnmounted(() => applyFullWidthBreakout(false));
 
 // Computed property for current collection fields
 const editingCollectionFields = computed(() => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,7 @@ export interface LayoutBlocksOptions {
   // Display
   viewMode?: 'grid' | 'list';      // Default: 'grid'
   compactMode?: boolean;           // Default: false
+  fullWidth?: boolean;             // Default: false — break out of the form column to full width
   showEmptyAreas?: boolean;        // Default: true
   
   // Advanced

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,6 +15,7 @@ export const DEFAULT_OPTIONS = {
   showEmptyAreas: true,
   viewMode: 'grid' as const,
   compactMode: false,
+  fullWidth: false,
   autoSetup: true,
   deleteItems: false,
   enableAreaManagement: false,


### PR DESCRIPTION
## Summary

- Adds an optional per-field interface option **Full Width** (`fullWidth`, default off) alongside the other display options.
- When enabled, the hosting `.field` spans the entire form grid (`grid-column: 1 / -1`), so the block editor uses the full form width even in `with-fill` forms (where a `full` field is otherwise capped at ~760px by `--form-column-max-width`).
- The form's standard horizontal padding is preserved — the editor keeps its normal left/right spacing instead of sticking to the edges.
- Implemented as an inline style on the ancestor `.field`, fully reverted when the option is off or the interface unmounts — no global CSS, no app-wide leak. Backward compatible (default off).

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes with 0 errors
- [x] `npm run test -- --run` passes (48/48)
- [x] `npm run build` succeeds
- [x] Verified live on `layout_demo/1`: enabling "Full Width" widens the editor to the full form width while keeping the standard padding; disabling (default) renders exactly as before.

Closes #75
