### PR TITLE
Inline block editing mode (editMode: inline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ On first open, the extension creates the `area` and `sort` fields on the junctio
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `viewMode` | `'grid' \| 'list'` | `'grid'` | Initial view mode. |
+| `editMode` | `'drawer' \| 'inline'` | `'drawer'` | How a block is edited: side **drawer**, or expanded **inline** in place (single-open accordion). |
 | `compactMode` | `boolean` | `false` | Denser block layout. |
 | `fullWidth` | `boolean` | `false` | Render the editor across the **full form width** (breaks out of the form column; padding preserved). |
 | `enableDragDrop` | `boolean` | `true` | Enable drag-and-drop reordering / moving. |
@@ -439,6 +440,11 @@ Logs are prefixed `[LayoutBlocks]`. See `utils/logger.ts` / `utils/logger-wrappe
 
 - **Nested M2A** — the data layer detects and loads nested M2A (up to depth 3), but there is **no
   nested rendering/editing UI**; only top-level blocks are shown.
+- **Editing a linked existing item edits the source.** Editing a block that links an existing item
+  (inline or via the drawer) and then saving deep-updates the **source item** — the change is visible
+  everywhere that item is linked. Reordering or moving a linked block does **not** change its content,
+  and status changes on a linked block are not persisted to the source. If the same source item is
+  linked twice in one record and both are edited, the two deep-updates race (last write wins).
 - **Not on npm** — install manually for now.
 
 ## Troubleshooting

--- a/src/components/BlockDirtyDot.vue
+++ b/src/components/BlockDirtyDot.vue
@@ -1,0 +1,52 @@
+<template>
+  <span
+    v-tooltip="isNew ? 'New block — not yet saved' : 'Unsaved changes'"
+    class="lb-dirty-dot"
+    :class="{ 'is-new': isNew }"
+    role="status"
+    :aria-label="isNew ? 'New, unsaved block' : 'Block has unsaved changes'"
+  />
+</template>
+
+<script setup lang="ts">
+interface Props {
+  /** Green (new/temp block) vs primary (edited existing block). */
+  isNew?: boolean;
+}
+withDefaults(defineProps<Props>(), { isNew: false });
+</script>
+
+<style lang="scss" scoped>
+/* Staged-change indicator — mirrors the sibling expandable-blocks dot. Values
+   inlined + `lb-`-namespaced class/keyframe so the scoped build does not collide
+   with that extension's global `.dirty-indicator` / `pulse` (see BlockItem.vue
+   style note + the extension-css-global-collision memory). The dot needs a
+   positioned ancestor (the host adds `position: relative`). */
+.lb-dirty-dot {
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--theme--primary);
+  border: 2px solid var(--theme--background);
+  box-sizing: content-box;
+  animation: lb-dirty-pulse 2s ease-in-out infinite;
+
+  &.is-new {
+    background: var(--theme--success);
+  }
+}
+
+@keyframes lb-dirty-pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.25); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lb-dirty-dot {
+    animation: none;
+  }
+}
+</style>

--- a/src/components/BlockItem.vue
+++ b/src/components/BlockItem.vue
@@ -4,13 +4,16 @@
     :class="{
       'compact': compact,
       'draggable': draggable,
-      'dragging': grabbed
+      'dragging': grabbed,
+      'expanded': expanded
     }"
     :data-block-id="block.id"
     :draggable="draggable"
     role="listitem"
     tabindex="0"
     :aria-roledescription="draggable ? 'sortable' : undefined"
+    :aria-expanded="inlineEdit ? expanded : undefined"
+    :aria-controls="inlineEdit && expanded ? `lb-inline-editor-${block.id}` : undefined"
     v-bind="$attrs"
     @click.stop="handleClick"
     @dblclick="handleDoubleClick"
@@ -21,6 +24,7 @@
         :name="getBlockIcon(block)" 
         :color="getBlockColor()"
       />
+      <block-dirty-dot v-if="isDirty" :is-new="isNewBlock" />
     </div>
 
     <!-- Block Content -->
@@ -72,6 +76,17 @@
               <v-icon name="edit" />
             </v-list-item-icon>
             <v-list-item-content>Edit</v-list-item-content>
+          </v-list-item>
+
+          <v-list-item
+            v-if="permissions.update && isDirty && !isNewBlock"
+            clickable
+            @click="$emit('revert')"
+          >
+            <v-list-item-icon>
+              <v-icon name="undo" />
+            </v-list-item-icon>
+            <v-list-item-content>Revert changes</v-list-item-content>
           </v-list-item>
 
           <v-list-item
@@ -136,8 +151,10 @@ import { computed, ref } from 'vue';
 import { vBtnAria } from '../directives/btnAria';
 import type { BlockItem, AreaConfig, UserPermissions } from '../types';
 import { getBlockIcon, getBlockTitle, getBlockSubtitle, getCollectionLabel } from '../utils/blockHelpers';
+import { isTempId } from '../utils/helpers';
 import StatusSelector from './StatusSelector.vue';
 import DeleteConfirmationDialog from './DeleteConfirmationDialog.vue';
+import BlockDirtyDot from './BlockDirtyDot.vue';
 
 // This component has multiple root nodes (the block element + the delete dialog),
 // so Vue cannot auto-inherit fallthrough listeners. Without this, the parent's
@@ -155,13 +172,25 @@ interface Props {
   draggable?: boolean;
   /** True while this block is held in keyboard drag mode (a11y §3). */
   grabbed?: boolean;
+  /** Inline edit mode: a single click toggles the inline editor. */
+  inlineEdit?: boolean;
+  /** True when this block's inline editor is open (single-open accordion). */
+  expanded?: boolean;
+  /** Block has staged, unsaved changes pending the global Save. */
+  isDirty?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   compact: false,
   draggable: true,
-  grabbed: false
+  grabbed: false,
+  inlineEdit: false,
+  expanded: false,
+  isDirty: false
 });
+
+// New/temp block (green dot) vs edited existing block (primary dot).
+const isNewBlock = computed(() => isTempId(props.block.id));
 
 // Emits
 const emit = defineEmits<{
@@ -172,6 +201,7 @@ const emit = defineEmits<{
   duplicate: [];
   click: [];
   'update-status': [status: string];
+  revert: [];
 }>();
 
 // State
@@ -197,7 +227,13 @@ function getBlockColor(): string {
 }
 
 function handleClick() {
-  emit('click');
+  // Inline mode: a single click toggles the inline editor (parent owns the
+  // single-open accordion via editingBlockId). Drawer mode keeps select-on-click.
+  if (props.inlineEdit) {
+    emit('edit');
+  } else {
+    emit('click');
+  }
 }
 
 function handleDoubleClick() {
@@ -285,9 +321,16 @@ function updateStatus(status: string) {
     border-style: dashed;
     cursor: grabbing !important;
   }
+
+  /* Active card whose inline editor is open (matches .grid-area.selected). */
+  &.expanded {
+    border-color: var(--theme--primary);
+    background: var(--theme--primary-background);
+  }
 }
 
 .block-icon {
+  position: relative;
   flex-shrink: 0;
   width: 40px;
   height: 40px;

--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -63,26 +63,44 @@
             class="blocks-container"
             role="list"
           >
-            <block-item-component
+            <div
               v-for="(block, index) in getAreaBlocks(area.id)"
               :key="block.id"
-              :block="block"
-              :index="index"
-              :area="area"
-              :compact="options.compactMode"
-              :permissions="permissions"
-              :draggable="options.enableDragDrop && (!area.locked || area.id === ORPHANED_AREA_ID)"
-              :grabbed="isBlockGrabbed(block.id)"
-              @edit="$emit('update-block', { blockId: block.id })"
-              @remove="$emit('remove-block', block.id)"
-              @unlink="$emit('unlink-block', block.id)"
-              @delete="$emit('delete-block', block.id, $event)"
-              @duplicate="$emit('duplicate-block', block.id)"
-              @update-status="handleBlockStatusUpdate(block, $event)"
-              @dragstart="handleDragStart($event, block, area)"
-              @dragend="handleDragEnd"
-              @keydown="handleBlockKeydown($event, block)"
-            />
+              class="lb-block-wrap"
+            >
+              <block-item-component
+                :block="block"
+                :index="index"
+                :area="area"
+                :compact="options.compactMode"
+                :permissions="permissions"
+                :inline-edit="options.editMode === 'inline'"
+                :expanded="editingBlockId === block.id"
+                :is-dirty="isBlockDirty?.(block.id) ?? false"
+                :draggable="options.enableDragDrop && (!area.locked || area.id === ORPHANED_AREA_ID)"
+                :grabbed="isBlockGrabbed(block.id)"
+                @edit="$emit('update-block', { blockId: block.id })"
+                @remove="$emit('remove-block', block.id)"
+                @unlink="$emit('unlink-block', block.id)"
+                @delete="$emit('delete-block', block.id, $event)"
+                @duplicate="$emit('duplicate-block', block.id)"
+                @update-status="handleBlockStatusUpdate(block, $event)"
+                @revert="$emit('revert-block', block.id)"
+                @dragstart="handleDragStart($event, block, area)"
+                @dragend="handleDragEnd"
+                @keydown="handleBlockKeydown($event, block)"
+              />
+              <InlineBlockEditor
+                v-if="options.editMode === 'inline' && editingBlockId === block.id"
+                :id="`lb-inline-editor-${block.id}`"
+                :collection="editingCollection || block.collection || ''"
+                :primary-key="editingPrimaryKey ?? '+'"
+                :model-value="block.item || {}"
+                :disabled="editDisabled"
+                @update:model-value="$emit('update-block-item', block.id, $event)"
+                @cancel="$emit('cancel-inline')"
+              />
+            </div>
           </transition-group>
 
           <!-- Empty State (shared EmptyState, dense for the constrained area card) -->
@@ -137,9 +155,11 @@ import type {
 } from '../types';
 import BlockItemComponent from './BlockItem.vue';
 import EmptyState from './EmptyState.vue';
+import InlineBlockEditor from './InlineBlockEditor.vue';
 import { createDragImage, getBlockTitle } from '../utils/blockHelpers';
 import { ORPHANED_AREA_ID } from '../utils/constants';
 import { useKeyboardDnd } from '../composables/useKeyboardDnd';
+import type { InlineEditViewProps, InlineEditViewEmits } from '../types/inline-edit-view';
 
 // Props
 interface Props {
@@ -152,7 +172,7 @@ interface Props {
   allowedCollections?: string[] | null;
 }
 
-const props = defineProps<Props>();
+const props = defineProps<Props & InlineEditViewProps>();
 
 // Number of skeleton placeholders shown per area while blocks are loading.
 const SKELETON_ROWS = 3;
@@ -195,7 +215,7 @@ const emit = defineEmits<{
   'add-block': [area?: string];
   'create-quick': [data: { area: string; collection: string }];
   'open-selector': [data: { area: string; collection: string }];
-}>();
+} & InlineEditViewEmits>();
 
 // Local State
 const draggedBlock = ref<BlockItem | null>(null);
@@ -227,10 +247,16 @@ function focusBlock(blockId: BlockId): void {
      nodes (leaving ghost + entering card). Focus the one that is NOT leaving. */
   const focusNonLeaving = () => {
     const nodes = rootEl.value?.querySelectorAll(`[data-block-id="${CSS.escape(String(blockId))}"]`);
-    const el = nodes && (Array.from(nodes).find((n) =>
-      !n.classList.contains('block-list-leave-active') &&
-      !n.classList.contains('block-list-leave-to')
-    ) as HTMLElement | undefined);
+    // The transition-group leave classes now sit on the .lb-block-wrap parent
+    // (the transition-group's direct child), not on .block-item — check both.
+    const isLeaving = (n: Element): boolean => {
+      const wrap = n.closest('.lb-block-wrap') ?? n;
+      return wrap.classList.contains('block-list-leave-active') ||
+        wrap.classList.contains('block-list-leave-to') ||
+        n.classList.contains('block-list-leave-active') ||
+        n.classList.contains('block-list-leave-to');
+    };
+    const el = nodes && (Array.from(nodes).find((n) => !isLeaving(n)) as HTMLElement | undefined);
     el?.focus();
   };
   nextTick(focusNonLeaving);          /* fast path (within-area moves) */
@@ -336,7 +362,8 @@ function handleDragStart(event: DragEvent, block: BlockItem, area: AreaConfig) {
 
   draggedBlock.value = block;
   draggedFromArea.value = area;
-  
+  emit('grab-start', block.id);
+
   // Set drag data
   event.dataTransfer!.effectAllowed = 'move';
   event.dataTransfer!.setData('block-id', block.id.toString());
@@ -664,6 +691,15 @@ function handleAddBlock(areaId: string) {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.lb-block-wrap {
+  display: block;
+
+  /* The inline editor sits directly under its card as one accordion row. */
+  > .lb-inline-editor {
+    margin-top: 8px;
+  }
 }
 
 .area-footer {

--- a/src/components/InlineBlockEditor.vue
+++ b/src/components/InlineBlockEditor.vue
@@ -1,0 +1,76 @@
+<template>
+  <!--
+    Live inline editor. Edits flow STRAIGHT into the block's item (no Save
+    button): the block is staged/dirty immediately and persisted on the global
+    Save, or discarded per-block via the block menu's "Revert changes". Close by
+    clicking the block again or pressing ESC — the staged edit is kept.
+
+    ESC is a BUBBLE-phase @keydown.esc on the root (NOT document-capture): nested
+    relational/file fields open TELEPORTED overlays under <body>, so their ESC
+    never bubbles here — they close themselves first. SCSS is inlined + `lb-`-
+    namespaced for the scoped build (see BlockItem.vue style note).
+  -->
+  <div
+    ref="root"
+    class="lb-inline-editor"
+    role="region"
+    :aria-label="`Edit ${collectionLabel}`"
+    tabindex="-1"
+    @keydown.esc="emit('cancel')"
+  >
+    <v-form
+      class="lb-inline-editor__form"
+      :collection="collection"
+      :primary-key="String(primaryKey)"
+      :model-value="modelValue"
+      :initial-values="modelValue"
+      :disabled="disabled"
+      @update:model-value="emit('update:modelValue', $event)"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+import { getCollectionLabel } from '../utils/blockHelpers';
+
+interface Props {
+  collection: string;
+  primaryKey: string | number;       // '+' for a new/create-mode block
+  modelValue: Record<string, any>;
+  disabled?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  disabled: false,
+});
+
+const emit = defineEmits<{
+  'update:modelValue': [value: Record<string, any>];
+  cancel: [];
+}>();
+
+const root = ref<HTMLElement | null>(null);
+const collectionLabel = computed(() => getCollectionLabel(props.collection));
+
+// Move focus into the editor region on open (keyboard/SR users land here).
+onMounted(() => {
+  root.value?.focus();
+});
+</script>
+
+<style lang="scss" scoped>
+.lb-inline-editor {
+  padding: 1rem;
+  border: var(--theme--border-width) solid var(--theme--border-color);
+  border-top: none;
+  border-bottom-left-radius: var(--theme--border-radius);
+  border-bottom-right-radius: var(--theme--border-radius);
+  background: var(--theme--background-subdued);
+
+  &:focus-visible {
+    outline: 2px solid var(--theme--primary);
+    outline-offset: -2px;
+  }
+}
+</style>

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -120,149 +120,149 @@
               v-for="block in selectedAreaBlocks"
               :key="block.id"
             >
-            <tr
-              class="block-row"
-              :class="{ 'kb-grabbed': kbIsGrabbed(block.id) }"
-              role="row"
-            >
-              <td v-if="showDragColumn" role="gridcell" class="drag-cell">
-                <div
-                  class="drag-handle"
-                  role="button"
-                  tabindex="0"
-                  aria-roledescription="sortable"
-                  :aria-label="`Reorder ${getBlockTitle(block)}`"
-                  :data-block-id="block.id"
-                  :draggable="true"
-                  @dragstart="handleDragStart($event, block)"
-                  @dragend="handleDragEnd"
-                  @keydown="handleBlockKeydown($event, block)"
-                >
-                  <v-icon name="drag_handle" />
-                </div>
-              </td>
-              
-              <td role="gridcell" class="icon-cell">
-                <span class="lb-icon-cell-inner">
-                  <v-icon :name="getBlockIcon(block)" />
-                  <block-dirty-dot v-if="isBlockDirty && isBlockDirty(block.id)" :is-new="isTempId(block.id)" />
-                </span>
-              </td>
-              
-              <td role="gridcell" class="title-cell">
-                <div class="block-title-cell">
-                  <strong>{{ getBlockTitle(block) }}</strong>
-                  <div v-if="getBlockSubtitle(block)" class="subtitle">
-                    {{ getBlockSubtitle(block) }}
+              <tr
+                class="block-row"
+                :class="{ 'kb-grabbed': kbIsGrabbed(block.id) }"
+                role="row"
+              >
+                <td v-if="showDragColumn" role="gridcell" class="drag-cell">
+                  <div
+                    class="drag-handle"
+                    role="button"
+                    tabindex="0"
+                    aria-roledescription="sortable"
+                    :aria-label="`Reorder ${getBlockTitle(block)}`"
+                    :data-block-id="block.id"
+                    :draggable="true"
+                    @dragstart="handleDragStart($event, block)"
+                    @dragend="handleDragEnd"
+                    @keydown="handleBlockKeydown($event, block)"
+                  >
+                    <v-icon name="drag_handle" />
                   </div>
-                </div>
-              </td>
+                </td>
               
-              <td role="gridcell" class="type-cell">
-                <v-chip small>{{ getCollectionLabel(block) }}</v-chip>
-              </td>
+                <td role="gridcell" class="icon-cell">
+                  <span class="lb-icon-cell-inner">
+                    <v-icon :name="getBlockIcon(block)" />
+                    <block-dirty-dot v-if="isBlockDirty && isBlockDirty(block.id)" :is-new="isTempId(block.id)" />
+                  </span>
+                </td>
               
-              <td role="gridcell" class="status-cell">
-                <status-selector
-                  v-if="block.item"
-                  :status="block.item.status"
-                  :editable="permissions.update"
-                  @update:status="updateBlockStatus(block, $event)"
-                />
-              </td>
+                <td role="gridcell" class="title-cell">
+                  <div class="block-title-cell">
+                    <strong>{{ getBlockTitle(block) }}</strong>
+                    <div v-if="getBlockSubtitle(block)" class="subtitle">
+                      {{ getBlockSubtitle(block) }}
+                    </div>
+                  </div>
+                </td>
               
-              <td v-if="showAreaColumn" role="gridcell" class="area-cell">
-                <v-chip 
-                  v-if="getAreaForBlock(block)"
-                  small
-                  :style="getAreaChipStyle(block)"
-                >
-                  <v-icon
-                    v-if="getAreaForBlock(block)?.icon"
-                    :name="getAreaForBlock(block).icon"
-                    x-small
-                    left
+                <td role="gridcell" class="type-cell">
+                  <v-chip small>{{ getCollectionLabel(block) }}</v-chip>
+                </td>
+              
+                <td role="gridcell" class="status-cell">
+                  <status-selector
+                    v-if="block.item"
+                    :status="block.item.status"
+                    :editable="permissions.update"
+                    @update:status="updateBlockStatus(block, $event)"
                   />
-                  {{ getAreaForBlock(block)?.label || block.area }}
-                </v-chip>
-                <v-chip v-else small class="orphaned-chip">
-                  <v-icon name="warning" x-small left />
-                  {{ block.area || 'None' }}
-                </v-chip>
-              </td>
+                </td>
               
-              <td role="gridcell" class="actions-cell">
-                <div class="actions-wrapper">
-                  <v-button
-                    v-if="permissions.update"
-                    v-tooltip="'Edit'"
-                    v-btn-aria="{ 'aria-label': 'Edit block', 'aria-expanded': editingBlockId === block.id }"
-                    icon
-                    x-small
-                    secondary
-                    :class="{ active: editingBlockId === block.id }"
-                    @click="$emit('update-block', { blockId: block.id })"
+                <td v-if="showAreaColumn" role="gridcell" class="area-cell">
+                  <v-chip 
+                    v-if="getAreaForBlock(block)"
+                    small
+                    :style="getAreaChipStyle(block)"
                   >
-                    <v-icon name="edit" />
-                  </v-button>
+                    <v-icon
+                      v-if="getAreaForBlock(block)?.icon"
+                      :name="getAreaForBlock(block).icon"
+                      x-small
+                      left
+                    />
+                    {{ getAreaForBlock(block)?.label || block.area }}
+                  </v-chip>
+                  <v-chip v-else small class="orphaned-chip">
+                    <v-icon name="warning" x-small left />
+                    {{ block.area || 'None' }}
+                  </v-chip>
+                </td>
+              
+                <td role="gridcell" class="actions-cell">
+                  <div class="actions-wrapper">
+                    <v-button
+                      v-if="permissions.update"
+                      v-tooltip="'Edit'"
+                      v-btn-aria="{ 'aria-label': 'Edit block', 'aria-expanded': editingBlockId === block.id }"
+                      icon
+                      x-small
+                      secondary
+                      :class="{ active: editingBlockId === block.id }"
+                      @click="$emit('update-block', { blockId: block.id })"
+                    >
+                      <v-icon name="edit" />
+                    </v-button>
 
-                  <v-button
-                    v-if="permissions.update && isBlockDirty && isBlockDirty(block.id) && !isTempId(block.id)"
-                    v-tooltip="'Revert changes'"
-                    v-btn-aria="{ 'aria-label': 'Revert changes' }"
-                    icon
-                    x-small
-                    secondary
-                    @click="$emit('revert-block', block.id)"
-                  >
-                    <v-icon name="undo" />
-                  </v-button>
+                    <v-button
+                      v-if="permissions.update && isBlockDirty && isBlockDirty(block.id) && !isTempId(block.id)"
+                      v-tooltip="'Revert changes'"
+                      v-btn-aria="{ 'aria-label': 'Revert changes' }"
+                      icon
+                      x-small
+                      secondary
+                      @click="$emit('revert-block', block.id)"
+                    >
+                      <v-icon name="undo" />
+                    </v-button>
 
-                  <v-button
-                    v-if="permissions.create"
-                    v-tooltip="'Duplicate'"
-                    v-btn-aria="{ 'aria-label': 'Duplicate block' }"
-                    icon
-                    x-small
-                    secondary
-                    @click="$emit('duplicate-block', block.id)"
-                  >
-                    <v-icon name="content_copy" />
-                  </v-button>
+                    <v-button
+                      v-if="permissions.create"
+                      v-tooltip="'Duplicate'"
+                      v-btn-aria="{ 'aria-label': 'Duplicate block' }"
+                      icon
+                      x-small
+                      secondary
+                      @click="$emit('duplicate-block', block.id)"
+                    >
+                      <v-icon name="content_copy" />
+                    </v-button>
 
-                  <v-button
-                    v-if="permissions.delete"
-                    v-tooltip="'Remove'"
-                    v-btn-aria="{ 'aria-label': 'Remove block' }"
-                    icon
-                    x-small
-                    secondary
-                    class="danger"
-                    @click="openDeleteDialog(block)"
-                  >
-                    <v-icon name="delete" />
-                  </v-button>
-                </div>
-              </td>
-            </tr>
+                    <v-button
+                      v-if="permissions.delete"
+                      v-tooltip="'Remove'"
+                      v-btn-aria="{ 'aria-label': 'Remove block' }"
+                      icon
+                      x-small
+                      secondary
+                      class="danger"
+                      @click="openDeleteDialog(block)"
+                    >
+                      <v-icon name="delete" />
+                    </v-button>
+                  </div>
+                </td>
+              </tr>
 
-            <tr
-              v-if="options.editMode === 'inline' && editingBlockId === block.id"
-              class="lb-inline-edit-row"
-              role="row"
-            >
-              <td :colspan="columnCount" role="gridcell">
-                <InlineBlockEditor
-                  :id="`lb-inline-editor-${block.id}`"
-                  :collection="editingCollection || block.collection || ''"
-                  :primary-key="editingPrimaryKey ?? '+'"
-                  :model-value="block.item || {}"
-                  :disabled="editDisabled"
-                  @update:model-value="$emit('update-block-item', block.id, $event)"
-                  @cancel="$emit('cancel-inline')"
-                />
-              </td>
-            </tr>
+              <tr
+                v-if="options.editMode === 'inline' && editingBlockId === block.id"
+                class="lb-inline-edit-row"
+                role="row"
+              >
+                <td :colspan="columnCount" role="gridcell">
+                  <InlineBlockEditor
+                    :id="`lb-inline-editor-${block.id}`"
+                    :collection="editingCollection || block.collection || ''"
+                    :primary-key="editingPrimaryKey ?? '+'"
+                    :model-value="block.item || {}"
+                    :disabled="editDisabled"
+                    @update:model-value="$emit('update-block-item', block.id, $event)"
+                    @cancel="$emit('cancel-inline')"
+                  />
+                </td>
+              </tr>
             </template>
           </tbody>
         </table>

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -81,7 +81,7 @@
         <table class="blocks-table" role="grid">
           <thead>
             <tr role="row">
-              <th v-if="options.enableDragDrop && (!selectedAreaConfig?.locked || selectedArea === ORPHANED_AREA_ID)" role="columnheader" style="width: 40px"></th>
+              <th v-if="showDragColumn" role="columnheader" style="width: 40px"></th>
               <th role="columnheader" style="width: 40px"></th>
               <th role="columnheader">
                 <div class="header-with-icon">
@@ -101,7 +101,7 @@
                   <span>Status</span>
                 </div>
               </th>
-              <th v-if="selectedArea === null || selectedArea === ORPHANED_AREA_ID" role="columnheader" style="width: 15%">
+              <th v-if="showAreaColumn" role="columnheader" style="width: 15%">
                 <div class="header-with-icon">
                   <v-icon name="dashboard" small />
                   <span>Area</span>
@@ -116,14 +116,16 @@
             </tr>
           </thead>
           <tbody>
-            <tr
+            <template
               v-for="block in selectedAreaBlocks"
               :key="block.id"
+            >
+            <tr
               class="block-row"
               :class="{ 'kb-grabbed': kbIsGrabbed(block.id) }"
               role="row"
             >
-              <td v-if="options.enableDragDrop && (!selectedAreaConfig?.locked || selectedArea === ORPHANED_AREA_ID)" role="gridcell" class="drag-cell">
+              <td v-if="showDragColumn" role="gridcell" class="drag-cell">
                 <div
                   class="drag-handle"
                   role="button"
@@ -141,7 +143,10 @@
               </td>
               
               <td role="gridcell" class="icon-cell">
-                <v-icon :name="getBlockIcon(block)" />
+                <span class="lb-icon-cell-inner">
+                  <v-icon :name="getBlockIcon(block)" />
+                  <block-dirty-dot v-if="isBlockDirty && isBlockDirty(block.id)" :is-new="isTempId(block.id)" />
+                </span>
               </td>
               
               <td role="gridcell" class="title-cell">
@@ -166,7 +171,7 @@
                 />
               </td>
               
-              <td v-if="selectedArea === null || selectedArea === ORPHANED_AREA_ID" role="gridcell" class="area-cell">
+              <td v-if="showAreaColumn" role="gridcell" class="area-cell">
                 <v-chip 
                   v-if="getAreaForBlock(block)"
                   small
@@ -191,13 +196,26 @@
                   <v-button
                     v-if="permissions.update"
                     v-tooltip="'Edit'"
-                    v-btn-aria="{ 'aria-label': 'Edit block' }"
+                    v-btn-aria="{ 'aria-label': 'Edit block', 'aria-expanded': editingBlockId === block.id }"
                     icon
                     x-small
                     secondary
+                    :class="{ active: editingBlockId === block.id }"
                     @click="$emit('update-block', { blockId: block.id })"
                   >
                     <v-icon name="edit" />
+                  </v-button>
+
+                  <v-button
+                    v-if="permissions.update && isBlockDirty && isBlockDirty(block.id) && !isTempId(block.id)"
+                    v-tooltip="'Revert changes'"
+                    v-btn-aria="{ 'aria-label': 'Revert changes' }"
+                    icon
+                    x-small
+                    secondary
+                    @click="$emit('revert-block', block.id)"
+                  >
+                    <v-icon name="undo" />
                   </v-button>
 
                   <v-button
@@ -227,6 +245,25 @@
                 </div>
               </td>
             </tr>
+
+            <tr
+              v-if="options.editMode === 'inline' && editingBlockId === block.id"
+              class="lb-inline-edit-row"
+              role="row"
+            >
+              <td :colspan="columnCount" role="gridcell">
+                <InlineBlockEditor
+                  :id="`lb-inline-editor-${block.id}`"
+                  :collection="editingCollection || block.collection || ''"
+                  :primary-key="editingPrimaryKey ?? '+'"
+                  :model-value="block.item || {}"
+                  :disabled="editDisabled"
+                  @update:model-value="$emit('update-block-item', block.id, $event)"
+                  @cancel="$emit('cancel-inline')"
+                />
+              </td>
+            </tr>
+            </template>
           </tbody>
         </table>
       </div>
@@ -277,7 +314,10 @@ import AddBlockDropdown from './AddBlockDropdown.vue';
 import StatusSelector from './StatusSelector.vue';
 import EmptyState from './EmptyState.vue';
 import DeleteConfirmationDialog from './DeleteConfirmationDialog.vue';
+import InlineBlockEditor from './InlineBlockEditor.vue';
+import BlockDirtyDot from './BlockDirtyDot.vue';
 import { createDragImage, getBlockIcon } from '../utils/blockHelpers';
+import { isTempId } from '../utils/helpers';
 import { ORPHANED_AREA_ID } from '../utils/constants';
 import { useKeyboardDnd } from '../composables/useKeyboardDnd';
 import { vBtnAria } from '../directives/btnAria';
@@ -288,6 +328,7 @@ import type {
   LayoutBlocksOptions,
   UserPermissions
 } from '../types';
+import type { InlineEditViewProps, InlineEditViewEmits } from '../types/inline-edit-view';
 
 // Props
 interface Props {
@@ -300,7 +341,7 @@ interface Props {
   allowedCollections?: string[] | null;
 }
 
-const props = defineProps<Props>();
+const props = defineProps<Props & InlineEditViewProps>();
 
 // Emits
 const emit = defineEmits<{
@@ -318,7 +359,7 @@ const emit = defineEmits<{
   'add-block': [area?: string];
   'create-quick': [data: { area: string; collection: string }];
   'open-selector': [data: { area: string; collection: string }];
-}>();
+} & InlineEditViewEmits>();
 
 // Local State
 const draggedBlock = ref<BlockItem | null>(null);
@@ -366,6 +407,20 @@ const selectedAreaConfig = computed(() => {
   logger.log('🟣 ListView: Selected area config:', config);
   return config;
 });
+
+/* Single source for the two conditional columns, used by the <th>/<td> v-ifs
+   AND the inline detail row's colspan so they can never drift. */
+const showDragColumn = computed(() =>
+  props.options.enableDragDrop &&
+  (!selectedAreaConfig.value?.locked || props.selectedArea === ORPHANED_AREA_ID)
+);
+
+const showAreaColumn = computed(() =>
+  props.selectedArea === null || props.selectedArea === ORPHANED_AREA_ID
+);
+
+/* icon + title + type + status + actions = 5 always-on, + drag, + area. */
+const columnCount = computed(() => 5 + (showDragColumn.value ? 1 : 0) + (showAreaColumn.value ? 1 : 0));
 
 const selectedAreaBlocks = computed(() => {
   if (props.selectedArea === null) {
@@ -587,6 +642,7 @@ function updateBlockStatus(block: BlockItem, newStatus: string) {
 // Drag & Drop
 function handleDragStart(event: DragEvent, block: BlockItem) {
   draggedBlock.value = block;
+  emit('grab-start', block.id);
   event.dataTransfer!.effectAllowed = 'move';
   event.dataTransfer!.setData('block-id', block.id.toString());
   event.dataTransfer!.setData('block-area', block.area || '');
@@ -986,6 +1042,20 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
       --v-button-color-hover: var(--theme--danger);
     }
   }
+}
+
+/* Inline-edit detail row: strip cell chrome so the editor fills the row.
+   It is a SIBLING of .block-row, so the .block-row td rules never match it. */
+.lb-inline-edit-row > td {
+  padding: 0;
+  border-right: none;
+  background-color: var(--theme--background-subdued);
+}
+
+/* Positioning context for the dirty-dot in the icon cell. */
+.lb-icon-cell-inner {
+  position: relative;
+  display: inline-flex;
 }
 
 .area-footer {

--- a/src/composables/useBlocks.ts
+++ b/src/composables/useBlocks.ts
@@ -3,7 +3,7 @@ import { ref, computed, unref, nextTick, type Ref, type ComputedRef } from 'vue'
 import { cloneDeep, isEqual } from 'lodash-es';
 import { useApi, useStores } from '@directus/extensions-sdk';
 import { M2AHelper } from '../utils/m2a-helper';
-import { generateTempId, isTempId, isExistingLink } from '../utils/helpers';
+import { generateTempId, isTempId, isExistingLink, isNewItemPk } from '../utils/helpers';
 import type {
   BlockItem,
   BlockId,
@@ -44,11 +44,52 @@ export function useBlocks(
   // the interface's value/blocks watchers against feedback loops during our own
   // emit and during loadBlocks().
   const dirtyIds = ref<Set<BlockId>>(new Set());
+  // Linked (existing_) blocks are ALWAYS dirty (temp id), so dirtyIds cannot
+  // distinguish "linked-only" from "linked-and-content-edited". This separate
+  // set marks links whose CONTENT was edited inline, so their source item is
+  // deep-updated on save (instead of emitting only the bare PK).
+  const contentEditedIds = ref<Set<BlockId>>(new Set());
+  // Original (last-loaded) item per block, keyed by String(id). Lets a single
+  // block be reverted to its persisted state before the global Save.
+  const blockOriginals = new Map<string, any>();
   const isInternalUpdate = ref(false);
 
   function markBlockDirty(id: BlockId, dirty = true): void {
     if (dirty) dirtyIds.value.add(id);
     else dirtyIds.value.delete(id);
+  }
+
+  function markContentEdited(id: BlockId): void {
+    contentEditedIds.value.add(id);
+  }
+
+  /**
+   * Live-stage an inline content edit: merge the new values into the block's
+   * item and mark it dirty + content-edited. Used by the inline editor on every
+   * change (no explicit Save — the global Save persists; revertBlock discards).
+   */
+  function updateBlockItem(id: BlockId, values: Record<string, any>): void {
+    const block = blocks.value.find(b => b.id === id);
+    if (!block) return;
+    block.item = { ...block.item, ...values };
+    markBlockDirty(id, true);
+    markContentEdited(id);
+  }
+
+  /**
+   * Revert a single block to its last-loaded (persisted) state, discarding its
+   * staged changes while leaving other blocks' staged changes intact. Returns
+   * false for blocks without an original (new/temp blocks — use delete instead).
+   */
+  function revertBlock(id: BlockId): boolean {
+    const original = blockOriginals.get(String(id));
+    if (original === undefined) return false;
+    const block = blocks.value.find(b => b.id === id);
+    if (!block) return false;
+    block.item = cloneDeep(original);
+    dirtyIds.value.delete(id);
+    contentEditedIds.value.delete(id);
+    return true;
   }
 
   /**
@@ -57,6 +98,7 @@ export function useBlocks(
    */
   function resetTracking(): void {
     dirtyIds.value.clear();
+    contentEditedIds.value.clear();
   }
 
   /**
@@ -79,7 +121,7 @@ export function useBlocks(
 
     // Skip loading if this is a new item
     const pk = unref(primaryKey);
-    if (!pk || pk === '+' || pk === 'new') {
+    if (isNewItemPk(pk)) {
       logger.log('New item detected, skipping block load');
       applyLoaded([]);
       return;
@@ -155,6 +197,10 @@ export function useBlocks(
       existing._raw = fresh._raw;
       return existing;
     });
+
+    // Snapshot the loaded (persisted) item per block as the revert baseline.
+    blockOriginals.clear();
+    for (const b of blocks.value) blockOriginals.set(String(b.id), cloneDeep(b.item));
 
     resetTracking();
     nextTick(() => {
@@ -276,6 +322,7 @@ export function useBlocks(
     // junction row on save (structured-deferred deletion).
     blocks.value = blocks.value.filter(b => b.id !== blockId);
     dirtyIds.value.delete(blockId);
+    contentEditedIds.value.delete(blockId);
 
     // Renumber the remaining blocks in the area with clean integer sorts.
     const remaining = blocks.value.filter(b => b.area === area).sort((a, b) => a.sort - b.sort);
@@ -390,8 +437,12 @@ export function useBlocks(
       if (hasSort) junction[sortField.value] = block.sort;
 
       if (isExistingLink(block.id)) {
-        // Link to existing item → bare PK only.
-        junction[itemField] = block.item?.id ?? block.item;
+        // Linked item: emit bare PK by default (source untouched). When the
+        // content was edited inline, emit the nested item WITH id so Directus
+        // deep-updates the shared source item (issue #77, accepted semantics).
+        junction[itemField] = contentEditedIds.value.has(block.id)
+          ? block.item
+          : (block.item?.id ?? block.item);
       } else if (temp) {
         // Truly new content → nested object without an id (create).
         const { id: _omitId, ...itemData } = block.item || {};
@@ -403,6 +454,16 @@ export function useBlocks(
 
       return junction;
     });
+  }
+
+  /**
+   * True if a block has unsaved (staged) changes pending the global Save:
+   * temp/new blocks (always), content-edited links, or any block marked dirty.
+   * Reads `dirtyIds.value.has()` directly so the reactive Set dependency is
+   * tracked by callers (a per-block predicate, not a copied Set).
+   */
+  function isBlockDirty(id: BlockId): boolean {
+    return isTempId(id) || dirtyIds.value.has(id) || contentEditedIds.value.has(id);
   }
 
   return {
@@ -421,6 +482,10 @@ export function useBlocks(
     reorderBlocks,
     moveBlock,
     markBlockDirty,
+    markContentEdited,
+    isBlockDirty,
+    updateBlockItem,
+    revertBlock,
     prepareItemsForEmit
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,6 +254,25 @@ export default defineInterface({
       }
     },
     {
+      field: 'editMode',
+      name: 'Edit Mode',
+      type: 'string',
+      meta: {
+        width: 'half',
+        interface: 'select-dropdown',
+        note: 'How a block is edited: in the side Drawer, or expanded Inline in place within the grid/list.',
+        options: {
+          choices: [
+            { text: 'Drawer', value: 'drawer' },
+            { text: 'Inline (expand in place)', value: 'inline' }
+          ]
+        }
+      },
+      schema: {
+        default_value: 'drawer'
+      }
+    },
+    {
       field: 'enableDragDrop',
       name: 'Enable Drag & Drop',
       type: 'boolean',

--- a/src/interface.vue
+++ b/src/interface.vue
@@ -181,6 +181,11 @@
           :permissions="permissions"
           :loading="blocksLoading"
           :allowed-collections="filteredCollections"
+          :editing-block-id="editingBlockId"
+          :editing-collection="editingCollection"
+          :editing-primary-key="editingId"
+          :edit-disabled="disabled"
+          :is-block-dirty="isBlockDirty"
           @move-block="handleMoveBlock"
           @remove-block="handleRemoveBlock"
           @unlink-block="handleUnlinkBlock"
@@ -190,6 +195,10 @@
           @add-block="openBlockCreator"
           @create-quick="handleQuickCreate"
           @open-selector="handleOpenSelector"
+          @grab-start="handleInlineGrabStart"
+          @update-block-item="handleInlineItemUpdate"
+          @revert-block="handleRevertBlock"
+          @cancel-inline="handleDrawerCancel"
         />
       </div>
 
@@ -256,6 +265,7 @@
       
       <!-- Edit Drawer mit v-form und eigenen Buttons -->
       <v-drawer
+        v-if="options.editMode !== EDIT_MODES.INLINE"
         v-model="drawerActive"
         :title="editingCollection ? `Edit ${getCollectionLabel(editingCollection)}` : 'Edit Block'"
         :subtitle="editingCollection ? 'Editing in place' : undefined"
@@ -336,9 +346,10 @@ import { useAutoSetup } from './composables/useAutoSetup';
 import { useBlocks } from './composables/useBlocks';
 import { usePermissions } from './composables/usePermissions';
 import { useBlockPermissions } from './composables/useBlockPermissions';
-import { DEFAULT_OPTIONS, DEFAULT_AREA_CONFIG, ORPHANED_AREA_ID } from './utils/constants';
-import { normalizeAreaIds, isTempId, formatCollectionName } from './utils/helpers';
+import { DEFAULT_OPTIONS, DEFAULT_AREA_CONFIG, ORPHANED_AREA_ID, EDIT_MODES } from './utils/constants';
+import { normalizeAreaIds, isTempId, formatCollectionName, isNewItemPk } from './utils/helpers';
 import { getCollectionIcon } from './utils/blockHelpers';
+import { nextInlineEditTarget } from './utils/inline-edit';
 import { cloneDeep } from 'lodash-es';
 import { CUSTOM_AREAS, USE_CUSTOM_AREAS } from './config/areas';
 import type {
@@ -483,8 +494,11 @@ onMounted(async () => {
         if (fieldConfig?.meta?.options) {
           // Force recompute if we find options
           if (fieldConfig.meta.options.areas && Array.isArray(fieldConfig.meta.options.areas)) {
-            if (options.value.areas?.length === 0 || !options.value.areas) {
-              // Reload blocks which should now use the correct areas
+            if ((options.value.areas?.length === 0 || !options.value.areas)
+              && editingBlockId.value === null
+              && !blocks.value.some(b => isBlockDirty(b.id))) {
+              // Reload blocks which should now use the correct areas — but NEVER
+              // while editing or with unsaved staged changes (would clobber them).
               loadBlocks();
             }
           }
@@ -567,6 +581,36 @@ function restoreOverlayTrigger() {
 watch(showAreaManager, (open, was) => { if (open) rememberOverlayTrigger(); else if (was) restoreOverlayTrigger(); });
 watch(showBlockCreator, (open, was) => { if (open) rememberOverlayTrigger(); else if (was) restoreOverlayTrigger(); });
 watch(drawerActive, (open, was) => { if (open) rememberOverlayTrigger(); else if (was) restoreOverlayTrigger(); });
+
+// Inline editor: close it when a drag of the OPEN block begins (pointer path;
+// keyboard moves are covered by handleMoveBlock). Closes the editor the moment
+// you start dragging it, so it never animates while being dragged.
+function handleInlineGrabStart(blockId: BlockId) {
+  if (editingBlockId.value !== null && String(blockId) === String(editingBlockId.value)) {
+    handleDrawerCancel();
+  }
+}
+
+// Close the inline editor when the view mode switches: <component :is> unmounts
+// the view (no KeepAlive), which would destroy the editor mid-edit, jump focus,
+// and leave editingBlockId set for a block that may be invisible in the other
+// view (issue #77).
+watch(viewMode, () => {
+  if (editingBlockId.value !== null) handleDrawerCancel();
+});
+
+// Inline editor focus restore: remember the block CARD as the restore target
+// (NOT document.activeElement — when opened via the teleported options menu,
+// activeElement is the menu item, which is removed on close → restore would
+// no-op). On close, return focus to the card.
+watch(editingBlockId, (open, was) => {
+  if (open !== null) {
+    const card = document.querySelector(`[data-block-id="${CSS.escape(String(open))}"]`);
+    lastOverlayTrigger.value = card instanceof HTMLElement ? card : null;
+  } else if (was !== null) {
+    restoreOverlayTrigger();
+  }
+});
 
 // Toolbar sticky-shadow: show a subtle shadow under the toolbar only once it is
 // stuck to the top (matching Directus' own header-bar). An IntersectionObserver
@@ -672,9 +716,7 @@ const { checkPermissions } = usePermissions();
 const { permissions: blockPermissions, validation } = useBlockPermissions(options);
 
 // Computed
-const isNewItem = computed(() => 
-  !props.primaryKey || props.primaryKey === '+' || props.primaryKey === 'new'
-);
+const isNewItem = computed(() => isNewItemPk(props.primaryKey));
 
 const viewComponent = computed(() => 
   viewMode.value === 'grid' ? GridView : ListView
@@ -754,6 +796,10 @@ const {
   reorderBlocks,
   moveBlock,
   markBlockDirty,
+  markContentEdited,
+  isBlockDirty,
+  updateBlockItem,
+  revertBlock,
   isInternalUpdate,
   prepareItemsForEmit
 } = useBlocks(
@@ -866,9 +912,12 @@ onMounted(async () => {
             // Since we can't use fieldOptions anymore, we need to force a recompute
             // by triggering a reactive update
             // This is a workaround for the delayed loading issue
-            if (options.value.areas?.length === 0 || !options.value.areas) {
+            if ((options.value.areas?.length === 0 || !options.value.areas)
+              && editingBlockId.value === null
+              && !blocks.value.some(b => isBlockDirty(b.id))) {
               logger.log('🔍 Options were empty, will reload page to apply areas');
               // As a last resort, reload the blocks which should now use the correct areas
+              // (skipped while editing / with unsaved staged changes — would clobber them).
               loadBlocks();
             }
           }
@@ -1034,6 +1083,7 @@ const filteredCollections = computed(() => {
 
 // Open block creator
 function openBlockCreator(area?: string) {
+  if (props.disabled) return;            // read-only interface: no adding
   logger.log('🔵 openBlockCreator called with area:', area);
   logger.log('🔵 Current selectedArea:', selectedArea.value);
   logger.log('🔵 isNewItem:', isNewItem.value);
@@ -1042,7 +1092,7 @@ function openBlockCreator(area?: string) {
   logger.log('🔵 junctionInfo:', junctionInfo.value);
   
   // Direct check for new item
-  const isNew = !props.primaryKey || props.primaryKey === '+' || props.primaryKey === 'new';
+  const isNew = isNewItemPk(props.primaryKey);
   logger.log('🔵 Direct isNew check:', isNew);
   
   if (isNew) {
@@ -1366,6 +1416,13 @@ async function handleMoveBlock(data: {
   toArea: string;
   toIndex: number;
 }) {
+  // Closing the open inline editor before a move prevents it from rendering in
+  // both the leaving ghost AND the entering card during the cross-area
+  // transition-group animation (issue #77).
+  if (editingBlockId.value !== null && String(data.blockId) === String(editingBlockId.value)) {
+    handleDrawerCancel();
+  }
+
   // Compare as strings: drag payloads from the DOM are strings, while persisted
   // blocks carry numeric ids (see fix #40/#42).
   const block = blocks.value.find(b => String(b.id) === String(data.blockId));
@@ -1406,19 +1463,42 @@ async function handleMoveBlock(data: {
 }
 
 async function handleUpdateBlock(data: {
-  blockId: number;
+  blockId: BlockId;
   updates?: any;
 }) {
   logger.log('🔵 handleUpdateBlock called:', data);
-  
-  // If updates are provided, do a direct update without opening drawer
+
+  // Direct status update path (unchanged).
   if (data.updates) {
     await handleBlockStatusUpdate(data.blockId, data.updates.status);
     return;
   }
-  
+
+  // Read-only interface: never open an editor.
+  if (props.disabled) return;
+
+  const inlineMode = options.value.editMode === EDIT_MODES.INLINE;
+
+  // Inline single-open accordion: re-triggering the open block closes it.
+  // No loading/buffer — block.item is already complete from the M2A load (the
+  // junction is fetched with `item.*`) and is edited LIVE: each change stages
+  // straight into the block (dirty), no Save button. Close keeps the edit;
+  // discard is per-block via the block menu's revert.
+  if (inlineMode) {
+    if (nextInlineEditTarget(editingBlockId.value, data.blockId) === null) {
+      handleDrawerCancel();
+      return;
+    }
+    const block = blocks.value.find(b => b.id === data.blockId);
+    if (!block) return;
+    editingCollection.value = block.collection;
+    editingBlockId.value = block.id;
+    editingId.value = (isTempId(block.id) || !block.item?.id) ? '+' : block.item.id;
+    return;
+  }
+
+  // Drawer mode: load the item into the buffer and open the side drawer.
   try {
-    // Find the block to get its collection and item id
     const block = blocks.value.find(b => b.id === data.blockId);
     if (!block) {
       throw new Error('Block not found');
@@ -1432,15 +1512,13 @@ async function handleUpdateBlock(data: {
       editingId.value = '+';
       editingValues.value = cloneDeep(block.item || {});
     } else {
-      // Persisted block: load current item values read-only for the form.
+      // Persisted block: load current item values for the form.
       editingId.value = block.item.id;
       const response = await api.get(`/items/${block.collection}/${block.item.id}`);
       editingValues.value = response.data.data;
     }
 
-    // Open drawer
     drawerActive.value = true;
-
   } catch (error) {
     logger.error('🔴 Error opening editor:', error);
     notifications.add({
@@ -1448,6 +1526,8 @@ async function handleUpdateBlock(data: {
       text: error.message || 'Failed to open block editor',
       type: 'error'
     });
+    // Fully close so no half-open empty inline editor remains.
+    handleDrawerCancel();
   }
 }
 
@@ -1567,6 +1647,7 @@ async function saveBlockDirectly() {
     if (block) {
       block.item = { ...block.item, ...editingValues.value };
       markBlockDirty(block.id, true);
+      markContentEdited(block.id);
     }
 
     notifications.add({
@@ -1594,13 +1675,33 @@ async function saveBlockDirectly() {
   }
 }
 
-// Handle drawer cancel
+// Handle drawer cancel (also used to close the inline accordion).
 function handleDrawerCancel() {
   drawerActive.value = false;
   editingId.value = null;
   editingBlockId.value = null;
   editingCollection.value = '';
   editingValues.value = {};
+}
+
+// Live inline edit: stage the change straight into the block's item (dirty).
+function handleInlineItemUpdate(blockId: BlockId, values: Record<string, any>) {
+  updateBlockItem(blockId, values);
+}
+
+// Revert a single block's staged changes (from the block menu).
+function handleRevertBlock(blockId: BlockId) {
+  if (revertBlock(blockId)) {
+    // If the reverted block's inline editor is open, close it for a clean state.
+    if (editingBlockId.value !== null && String(editingBlockId.value) === String(blockId)) {
+      handleDrawerCancel();
+    }
+    notifications.add({
+      title: 'Changes reverted',
+      text: 'The block was restored to its saved state.',
+      type: 'success'
+    });
+  }
 }
 
 // Get foreign key field for circular reference prevention
@@ -1836,6 +1937,10 @@ watch(blocks, () => {
 // read-only and reset the dirty baseline. Skipped for our own emits.
 watch(() => props.value, () => {
   if (isInternalUpdate.value) return;
+  // A real (Save / Discard / external) reload ends any open edit session — close
+  // the inline editor first so it never points at a stale/replaced block (e.g. a
+  // new block whose temp id became a real id after Save & Stay).
+  if (editingBlockId.value !== null) handleDrawerCancel();
   loadBlocks();
 }, { deep: true });
 </script>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,6 +13,7 @@ export interface LayoutBlocksOptions {
   
   // Display
   viewMode?: 'grid' | 'list';      // Default: 'grid'
+  editMode?: 'drawer' | 'inline';  // Default: 'drawer' — where block editing happens
   compactMode?: boolean;           // Default: false
   fullWidth?: boolean;             // Default: false — break out of the form column to full width
   showEmptyAreas?: boolean;        // Default: true

--- a/src/types/inline-edit-view.ts
+++ b/src/types/inline-edit-view.ts
@@ -1,0 +1,31 @@
+import type { BlockId } from './index';
+
+/**
+ * Inline-edit state passed from interface.vue down to GridView/ListView.
+ * Shared between both views so the contract cannot drift (the dynamic
+ * `<component :is>` host is NOT strictly type-checked by vue-tsc).
+ * `editMode` itself is read from the existing `options.editMode`.
+ */
+export interface InlineEditViewProps {
+  editingBlockId?: BlockId | null;
+  editingCollection?: string;
+  editingPrimaryKey?: string | number | null;
+  editDisabled?: boolean;
+  /** Per-block staged-changes predicate (drives the dirty indicator dot). */
+  isBlockDirty?: (id: BlockId) => boolean;
+}
+
+/**
+ * Inline-edit events both views emit upward. Each view keeps its OWN
+ * view-specific emits (e.g. the divergent `update-block` payload) local and
+ * intersects them with this type.
+ */
+export interface InlineEditViewEmits {
+  /** Live content edit from the inline form → stage into the block's item. */
+  'update-block-item': [id: BlockId, values: Record<string, any>];
+  /** Revert a single block's staged changes (from the block menu). */
+  'revert-block': [id: BlockId];
+  'grab-start': [blockId: BlockId];
+  /** Close the inline editor (ESC) — staged edits are kept. */
+  'cancel-inline': [];
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -14,6 +14,7 @@ export const DEFAULT_OPTIONS = {
   enableDragDrop: true,
   showEmptyAreas: true,
   viewMode: 'grid' as const,
+  editMode: 'drawer' as const,
   compactMode: false,
   fullWidth: false,
   autoSetup: true,
@@ -28,6 +29,11 @@ export const FIELD_NAME_ALTERNATIVES = {
 export const VIEW_MODES = {
   GRID: 'grid',
   LIST: 'list'
+} as const;
+
+export const EDIT_MODES = {
+  DRAWER: 'drawer',
+  INLINE: 'inline'
 } as const;
 
 export const DRAG_ANIMATION_DURATION = 200;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -52,6 +52,14 @@ export function isExistingLink(id: unknown): boolean {
 }
 
 /**
+ * Check if a primary key denotes a new (unsaved) item. Directus uses both `'+'`
+ * (current) and the legacy `'new'`; a nullish key is also treated as new.
+ */
+export function isNewItemPk(pk: unknown): boolean {
+  return !pk || pk === '+' || pk === 'new';
+}
+
+/**
  * Format collection name for display
  */
 export function formatCollectionName(collection: string): string {

--- a/src/utils/inline-edit.ts
+++ b/src/utils/inline-edit.ts
@@ -1,0 +1,19 @@
+import type { BlockId } from '../types';
+
+/**
+ * Single-open accordion decision. Given the currently-open block id (or null)
+ * and the just-triggered block id, return the next id to open — or `null` to
+ * close. Clicking the open block closes it; clicking another switches to it —
+ * the previous block stays staged/dirty (live edits are KEPT, not discarded; use
+ * the per-block revert to discard a single block's staged changes).
+ *
+ * Strict `===` is intentional: persisted ids are numeric and temp ids are
+ * prefixed strings, so a numeric `10` and a string `"10"` never refer to the
+ * same junction. Do NOT loosen this comparison.
+ */
+export function nextInlineEditTarget(
+  currentEditingId: BlockId | null,
+  clickedId: BlockId,
+): BlockId | null {
+  return currentEditingId === clickedId ? null : clickedId;
+}

--- a/test/unit/composables/useBlocks.test.ts
+++ b/test/unit/composables/useBlocks.test.ts
@@ -322,4 +322,25 @@ describe('useBlocks Composable (global-save / state-based)', () => {
       expect(out[0].item).toBe(7);                     // bare PK — no deep update
     });
   });
+
+  describe('revertBlock (per-block discard)', () => {
+    it('restores a block to its loaded original and clears its dirty state', async () => {
+      const { updateBlockItem, revertBlock, isBlockDirty, blocks } = await seed([
+        baseRecord({ id: 10, item: { id: 5, title: 'Original' } })
+      ]);
+      updateBlockItem(10, { title: 'Edited' });
+      expect(blocks.value[0].item.title).toBe('Edited');
+      expect(isBlockDirty(10)).toBe(true);
+
+      expect(revertBlock(10)).toBe(true);
+      expect(blocks.value[0].item.title).toBe('Original');
+      expect(isBlockDirty(10)).toBe(false);
+    });
+
+    it('returns false for a block with no original (a new/temp block)', async () => {
+      const { revertBlock, addBlock, blocks } = await seed([]);
+      await addBlock('main', 'content_text', { title: 'New' });
+      expect(revertBlock(blocks.value[0].id)).toBe(false);
+    });
+  });
 });

--- a/test/unit/composables/useBlocks.test.ts
+++ b/test/unit/composables/useBlocks.test.ts
@@ -289,5 +289,37 @@ describe('useBlocks Composable (global-save / state-based)', () => {
         expect(Number.isInteger(entry.sort)).toBe(true);
       }
     });
+
+    it('emits the nested linked item WITH id when content was edited (deep update)', async () => {
+      mockApi.get.mockResolvedValueOnce({ data: { data: { id: 7, title: 'Linked' } } });
+      const { prepareItemsForEmit, linkExistingItem, markContentEdited, blocks } = await seed([]);
+      await linkExistingItem('main', 'content_text', 7);
+      const id = blocks.value[0].id;          // existing_… temp id
+      blocks.value[0].item.title = 'Edited';  // simulate the staged drawer edit
+      markContentEdited(id);
+      const out = prepareItemsForEmit();
+      expect(out[0]).toMatchObject({
+        collection: 'content_text',
+        area: 'main',
+        item: { id: 7, title: 'Edited' }
+      });
+      expect(out[0]).not.toHaveProperty('id'); // temp junction → no junction id
+    });
+
+    it('keeps the bare PK for a linked block whose item was mutated but NOT content-marked', async () => {
+      // Proves the deep-update gate is markContentEdited, not mere dirtiness: a
+      // linked block is always dirty (temp id) and can even have a locally
+      // mutated item, but without markContentEdited it still emits the bare PK
+      // (source untouched). This is the real counter-test to the positive case.
+      mockApi.get.mockResolvedValueOnce({ data: { data: { id: 7, title: 'Linked' } } });
+      const { prepareItemsForEmit, linkExistingItem, reorderBlocks, blocks } = await seed([]);
+      await linkExistingItem('main', 'content_text', 7);
+      const id = blocks.value[0].id;
+      blocks.value[0].item.title = 'Edited locally';  // mutated, but NOT marked
+      await reorderBlocks('main', [id]);               // dirty, not content-edited
+      const out = prepareItemsForEmit();
+      expect(out[0]).toMatchObject({ collection: 'content_text', area: 'main', item: 7 });
+      expect(out[0].item).toBe(7);                     // bare PK — no deep update
+    });
   });
 });

--- a/test/unit/constants.test.ts
+++ b/test/unit/constants.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_OPTIONS, EDIT_MODES } from '../../src/utils/constants';
+
+describe('DEFAULT_OPTIONS', () => {
+  it("defaults editMode to 'drawer' (inline must be strictly opt-in)", () => {
+    expect(DEFAULT_OPTIONS.editMode).toBe('drawer');
+  });
+
+  it('keeps existing defaults intact when editMode is added', () => {
+    expect(DEFAULT_OPTIONS.viewMode).toBe('grid');
+    expect(DEFAULT_OPTIONS.enableDragDrop).toBe(true);
+    expect(DEFAULT_OPTIONS.showEmptyAreas).toBe(true);
+    expect(DEFAULT_OPTIONS.enableAreaManagement).toBe(false);
+  });
+});
+
+describe('EDIT_MODES', () => {
+  it('exposes drawer and inline values', () => {
+    expect(EDIT_MODES.DRAWER).toBe('drawer');
+    expect(EDIT_MODES.INLINE).toBe('inline');
+  });
+});

--- a/test/unit/inline-edit.test.ts
+++ b/test/unit/inline-edit.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { isNewItemPk } from '../../src/utils/helpers';
+import { nextInlineEditTarget } from '../../src/utils/inline-edit';
+
+describe('isNewItemPk', () => {
+  it("treats '+' and 'new' and nullish as a new (unsaved) item", () => {
+    expect(isNewItemPk('+')).toBe(true);
+    expect(isNewItemPk('new')).toBe(true);
+    expect(isNewItemPk(null)).toBe(true);
+    expect(isNewItemPk(undefined)).toBe(true);
+  });
+
+  it('treats a real primary key as an existing item', () => {
+    expect(isNewItemPk(1)).toBe(false);
+    expect(isNewItemPk('42')).toBe(false);
+  });
+});
+
+describe('nextInlineEditTarget (single-open accordion)', () => {
+  it('opens a block when nothing is open', () => {
+    expect(nextInlineEditTarget(null, 10)).toBe(10);
+  });
+  it('closes when the open block is clicked again (toggle)', () => {
+    expect(nextInlineEditTarget(10, 10)).toBeNull();
+  });
+  it('switches to another block (single-open)', () => {
+    expect(nextInlineEditTarget(10, 11)).toBe(11);
+  });
+  it('handles temporary string ids by value', () => {
+    expect(nextInlineEditTarget('new_1_a', 'new_1_a')).toBeNull();
+    expect(nextInlineEditTarget('new_1_a', 12)).toBe(12);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an `editMode: 'drawer' | 'inline'` interface option (default `drawer`). Inline mode edits a block in an **expand-in-place** form within the area instead of the side drawer — integrated with the existing global Save / Discard model.

- **Live staging** — editing flows straight into the block (no per-form Save); a pulsing dirty dot (green = new, blue = edited) marks blocks with unsaved staged changes.
- **Per-block revert** — from the block menu (grid) / row action (list), via an original-state snapshot, to discard a single block's changes without affecting others.
- **Linked existing items** — inline content edits are deep-updated to the source item on the global Save.
- **Single-open accordion**; the drawer mode is unchanged.

Also: `editMode` option/type/default, an `isNewItemPk` helper (3 existing call-sites migrated), shared view prop/emit types, and a README limitations note.

## Test plan

- **Unit:** `editMode` default, the `nextInlineEditTarget` toggle, `isNewItemPk`, and the linked-item deep-update emit shape → `npm run test -- --run` = **59 passing**.
- **Gates:** `npm run type-check` ✅, `npm run lint` 0 errors, `npm run build` ✔.
- **Live (pending, via /pt):** a realistic example is set up at `inline_demo/1` (grid + list × multiple areas × content types) — click a block → inline form expands; edit → dirty dot appears; revert restores one block; global Save persists. Includes complex-field cursor check (rich-text/relational) and the deferred expand animation.

Part of #77
