### PR TITLE
Animate inline editor expand/collapse

### DIFF
--- a/src/components/GridView.vue
+++ b/src/components/GridView.vue
@@ -90,16 +90,28 @@
                 @dragend="handleDragEnd"
                 @keydown="handleBlockKeydown($event, block)"
               />
-              <InlineBlockEditor
-                v-if="options.editMode === 'inline' && editingBlockId === block.id"
-                :id="`lb-inline-editor-${block.id}`"
-                :collection="editingCollection || block.collection || ''"
-                :primary-key="editingPrimaryKey ?? '+'"
-                :model-value="block.item || {}"
-                :disabled="editDisabled"
-                @update:model-value="$emit('update-block-item', block.id, $event)"
-                @cancel="$emit('cancel-inline')"
-              />
+              <transition
+                :css="false"
+                @enter="onEnter"
+                @leave="onLeave"
+                @enter-cancelled="onEnterCancelled"
+                @leave-cancelled="onLeaveCancelled"
+              >
+                <div
+                  v-if="options.editMode === 'inline' && editingBlockId === block.id"
+                  class="lb-inline-anim"
+                >
+                  <InlineBlockEditor
+                    :id="`lb-inline-editor-${block.id}`"
+                    :collection="editingCollection || block.collection || ''"
+                    :primary-key="editingPrimaryKey ?? '+'"
+                    :model-value="block.item || {}"
+                    :disabled="editDisabled"
+                    @update:model-value="$emit('update-block-item', block.id, $event)"
+                    @cancel="$emit('cancel-inline')"
+                  />
+                </div>
+              </transition>
             </div>
           </transition-group>
 
@@ -159,6 +171,7 @@ import InlineBlockEditor from './InlineBlockEditor.vue';
 import { createDragImage, getBlockTitle } from '../utils/blockHelpers';
 import { ORPHANED_AREA_ID } from '../utils/constants';
 import { useKeyboardDnd } from '../composables/useKeyboardDnd';
+import { useInlineExpand } from '../composables/useInlineExpand';
 import type { InlineEditViewProps, InlineEditViewEmits } from '../types/inline-edit-view';
 
 // Props
@@ -173,6 +186,10 @@ interface Props {
 }
 
 const props = defineProps<Props & InlineEditViewProps>();
+
+// Inline-editor expand/collapse animation. In the grid the transition element
+// IS the sized wrapper (.lb-inline-anim), so no inner selector is needed.
+const { onEnter, onLeave, onEnterCancelled, onLeaveCancelled } = useInlineExpand();
 
 // Number of skeleton placeholders shown per area while blocks are loading.
 const SKELETON_ROWS = 3;
@@ -696,9 +713,13 @@ function handleAddBlock(areaId: string) {
 .lb-block-wrap {
   display: block;
 
-  /* The inline editor sits directly under its card as one accordion row. */
-  > .lb-inline-editor {
-    margin-top: 8px;
+  /* The inline editor sits directly under its card as one accordion row. The
+     8px gap lives INSIDE the animated wrapper (padding, not margin) with
+     border-box sizing, so it collapses with the height animation instead of
+     leaving a stray gap below the card while closing. */
+  > .lb-inline-anim {
+    box-sizing: border-box;
+    padding-top: 8px;
   }
 }
 

--- a/src/components/InlineBlockEditor.vue
+++ b/src/components/InlineBlockEditor.vue
@@ -54,8 +54,11 @@ const root = ref<HTMLElement | null>(null);
 const collectionLabel = computed(() => getCollectionLabel(props.collection));
 
 // Move focus into the editor region on open (keyboard/SR users land here).
+// preventScroll: focus runs while the inline-expand animation still has the
+// editor at height:0 — without it the browser scrolls to reveal the 0px target,
+// jumping the page when a block low in a long list is opened.
 onMounted(() => {
-  root.value?.focus();
+  root.value?.focus({ preventScroll: true });
 });
 </script>
 

--- a/src/components/ListView.vue
+++ b/src/components/ListView.vue
@@ -246,23 +246,33 @@
                 </td>
               </tr>
 
-              <tr
-                v-if="options.editMode === 'inline' && editingBlockId === block.id"
-                class="lb-inline-edit-row"
-                role="row"
+              <transition
+                :css="false"
+                @enter="onEnter"
+                @leave="onLeave"
+                @enter-cancelled="onEnterCancelled"
+                @leave-cancelled="onLeaveCancelled"
               >
-                <td :colspan="columnCount" role="gridcell">
-                  <InlineBlockEditor
-                    :id="`lb-inline-editor-${block.id}`"
-                    :collection="editingCollection || block.collection || ''"
-                    :primary-key="editingPrimaryKey ?? '+'"
-                    :model-value="block.item || {}"
-                    :disabled="editDisabled"
-                    @update:model-value="$emit('update-block-item', block.id, $event)"
-                    @cancel="$emit('cancel-inline')"
-                  />
-                </td>
-              </tr>
+                <tr
+                  v-if="options.editMode === 'inline' && editingBlockId === block.id"
+                  class="lb-inline-edit-row"
+                  role="row"
+                >
+                  <td :colspan="columnCount" role="gridcell">
+                    <div class="lb-inline-anim">
+                      <InlineBlockEditor
+                        :id="`lb-inline-editor-${block.id}`"
+                        :collection="editingCollection || block.collection || ''"
+                        :primary-key="editingPrimaryKey ?? '+'"
+                        :model-value="block.item || {}"
+                        :disabled="editDisabled"
+                        @update:model-value="$emit('update-block-item', block.id, $event)"
+                        @cancel="$emit('cancel-inline')"
+                      />
+                    </div>
+                  </td>
+                </tr>
+              </transition>
             </template>
           </tbody>
         </table>
@@ -320,6 +330,7 @@ import { createDragImage, getBlockIcon } from '../utils/blockHelpers';
 import { isTempId } from '../utils/helpers';
 import { ORPHANED_AREA_ID } from '../utils/constants';
 import { useKeyboardDnd } from '../composables/useKeyboardDnd';
+import { useInlineExpand } from '../composables/useInlineExpand';
 import { vBtnAria } from '../directives/btnAria';
 import type {
   BlockItem,
@@ -342,6 +353,11 @@ interface Props {
 }
 
 const props = defineProps<Props & InlineEditViewProps>();
+
+// Inline-editor expand/collapse animation. The transition element is the <tr>,
+// which cannot be height-animated directly — animate the inner .lb-inline-anim
+// wrapper instead and let the row follow.
+const { onEnter, onLeave, onEnterCancelled, onLeaveCancelled } = useInlineExpand('.lb-inline-anim');
 
 // Emits
 const emit = defineEmits<{
@@ -1050,6 +1066,13 @@ function canDropInArea(block: BlockItem, area: AreaConfig): boolean {
   padding: 0;
   border-right: none;
   background-color: var(--theme--background-subdued);
+}
+
+/* Height-animated wrapper inside the inline-edit cell (see useInlineExpand). The
+   <tr> can't be height-animated, so this inner div is; the row follows it.
+   border-box keeps any future padding inside the measured/animated height. */
+.lb-inline-edit-row .lb-inline-anim {
+  box-sizing: border-box;
 }
 
 /* Positioning context for the dirty-dot in the icon cell. */

--- a/src/composables/useInlineExpand.ts
+++ b/src/composables/useInlineExpand.ts
@@ -1,0 +1,101 @@
+/**
+ * Inline-editor expand/collapse animation — a height accordion driven by Vue
+ * <transition> JS hooks (NOT CSS classes), shared by GridView and ListView.
+ *
+ * Why JS hooks (`:css="false"`) instead of a CSS `grid-template-rows` trick:
+ *  - The list editor lives in a <tr>, which cannot be height-animated via CSS;
+ *    here we animate an inner wrapper and let the row follow.
+ *  - A plain `v-if` pops, and a <tr> unmounts before any CSS leave could run.
+ *    With `:css="false"` Vue keeps the element mounted until done() fires, so
+ *    BOTH open and close animate.
+ *
+ * Fine-tune the feel via INLINE_EXPAND_MS / INLINE_EXPAND_EASING — the single
+ * source of truth (the inline `transition` is written from these; there is no
+ * duplicated CSS duration to keep in sync). Honors `prefers-reduced-motion`
+ * (a11y §5): the animation is skipped and the editor appears/disappears at once.
+ */
+
+// Expand/collapse duration (ms) and easing — tweak here to fine-tune the feel.
+export const INLINE_EXPAND_MS = 220;
+export const INLINE_EXPAND_EASING = 'ease';
+
+type DoneFn = () => void;
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * @param targetSelector  When the transition element is not the element we want
+ *   to size (e.g. a <tr> in the list), the inner element to actually animate.
+ *   Omit for the grid, where the transition element IS the sized wrapper.
+ */
+export function useInlineExpand(targetSelector?: string) {
+  // The element whose height we animate (may differ from the transition element).
+  function resolveTarget(el: Element): HTMLElement {
+    if (targetSelector) {
+      const inner = el.querySelector(targetSelector);
+      if (inner) return inner as HTMLElement;
+    }
+    return el as HTMLElement;
+  }
+
+  // Strip every inline style we set, returning the element to its natural
+  // (auto-height, visible-overflow) state.
+  function reset(t: HTMLElement): void {
+    t.style.height = '';
+    t.style.overflow = '';
+    t.style.opacity = '';
+    t.style.transition = '';
+  }
+
+  // Animate `t` between two explicit heights, fading opacity in step. A fallback
+  // timer guarantees done() even when no `transitionend` fires (height unchanged,
+  // zero-height layouts, interrupted transition) so the editor never gets stuck.
+  function animate(t: HTMLElement, from: string, to: string, done: DoneFn): void {
+    t.style.overflow = 'hidden';
+    t.style.height = from;
+    t.style.opacity = from === '0px' ? '0' : '1';
+    // Force a reflow so the start values are committed before we transition.
+    t.getBoundingClientRect();
+    t.style.transition =
+      `height ${INLINE_EXPAND_MS}ms ${INLINE_EXPAND_EASING}, opacity ${INLINE_EXPAND_MS}ms ${INLINE_EXPAND_EASING}`;
+    t.style.height = to;
+    t.style.opacity = to === '0px' ? '0' : '1';
+
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      t.removeEventListener('transitionend', onEnd);
+      clearTimeout(timer);
+      reset(t);
+      done();
+    };
+    const onEnd = (e: Event): void => {
+      if (e.target === t && (e as TransitionEvent).propertyName === 'height') finish();
+    };
+    const timer = setTimeout(finish, INLINE_EXPAND_MS + 80);
+    t.addEventListener('transitionend', onEnd);
+  }
+
+  function onEnter(el: Element, done: DoneFn): void {
+    const t = resolveTarget(el);
+    if (prefersReducedMotion()) { done(); return; }
+    animate(t, '0px', `${t.scrollHeight}px`, done);
+  }
+
+  function onLeave(el: Element, done: DoneFn): void {
+    const t = resolveTarget(el);
+    if (prefersReducedMotion()) { done(); return; }
+    animate(t, `${t.scrollHeight}px`, '0px', done);
+  }
+
+  // Interrupted mid-flight (e.g. rapid open→close): drop our inline styles.
+  function onEnterCancelled(el: Element): void { reset(resolveTarget(el)); }
+  function onLeaveCancelled(el: Element): void { reset(resolveTarget(el)); }
+
+  return { onEnter, onLeave, onEnterCancelled, onLeaveCancelled };
+}

--- a/src/composables/useInlineExpand.ts
+++ b/src/composables/useInlineExpand.ts
@@ -33,6 +33,11 @@ function prefersReducedMotion(): boolean {
  *   Omit for the grid, where the transition element IS the sized wrapper.
  */
 export function useInlineExpand(targetSelector?: string) {
+  // The in-flight animation's stopper, per element. Lets a new animation (or a
+  // cancel hook) supersede a running one — clearing its timer + listener so a
+  // stale safety timer can never resolve or clobber a later animation.
+  const active = new WeakMap<HTMLElement, () => void>();
+
   // The element whose height we animate (may differ from the transition element).
   function resolveTarget(el: Element): HTMLElement {
     if (targetSelector) {
@@ -51,26 +56,36 @@ export function useInlineExpand(targetSelector?: string) {
     t.style.transition = '';
   }
 
-  // Animate `t` between two explicit heights, fading opacity in step. A fallback
+  // Animate `t` open (`expanding`) or closed, fading opacity in step. A fallback
   // timer guarantees done() even when no `transitionend` fires (height unchanged,
   // zero-height layouts, interrupted transition) so the editor never gets stuck.
-  function animate(t: HTMLElement, from: string, to: string, done: DoneFn): void {
+  function animate(t: HTMLElement, expanding: boolean, done: DoneFn): void {
+    active.get(t)?.(); // supersede any in-flight animation on this element
+
+    const full = `${t.scrollHeight}px`;
     t.style.overflow = 'hidden';
-    t.style.height = from;
-    t.style.opacity = from === '0px' ? '0' : '1';
+    t.style.height = expanding ? '0px' : full;
+    t.style.opacity = expanding ? '0' : '1';
     // Force a reflow so the start values are committed before we transition.
     t.getBoundingClientRect();
     t.style.transition =
       `height ${INLINE_EXPAND_MS}ms ${INLINE_EXPAND_EASING}, opacity ${INLINE_EXPAND_MS}ms ${INLINE_EXPAND_EASING}`;
-    t.style.height = to;
-    t.style.opacity = to === '0px' ? '0' : '1';
+    t.style.height = expanding ? full : '0px';
+    t.style.opacity = expanding ? '1' : '0';
 
     let settled = false;
-    const finish = (): void => {
+    // Stop the timer + listener WITHOUT resolving (used when superseded/cancelled).
+    const stop = (): void => {
       if (settled) return;
       settled = true;
       t.removeEventListener('transitionend', onEnd);
       clearTimeout(timer);
+      if (active.get(t) === stop) active.delete(t);
+    };
+    // Natural completion: stop, restore natural styles, resolve the transition.
+    const finish = (): void => {
+      if (settled) return;
+      stop();
       reset(t);
       done();
     };
@@ -79,23 +94,34 @@ export function useInlineExpand(targetSelector?: string) {
     };
     const timer = setTimeout(finish, INLINE_EXPAND_MS + 80);
     t.addEventListener('transitionend', onEnd);
+    active.set(t, stop);
   }
 
   function onEnter(el: Element, done: DoneFn): void {
     const t = resolveTarget(el);
     if (prefersReducedMotion()) { done(); return; }
-    animate(t, '0px', `${t.scrollHeight}px`, done);
+    animate(t, true, done);
   }
 
   function onLeave(el: Element, done: DoneFn): void {
     const t = resolveTarget(el);
     if (prefersReducedMotion()) { done(); return; }
-    animate(t, `${t.scrollHeight}px`, '0px', done);
+    animate(t, false, done);
   }
 
-  // Interrupted mid-flight (e.g. rapid open→close): drop our inline styles.
-  function onEnterCancelled(el: Element): void { reset(resolveTarget(el)); }
-  function onLeaveCancelled(el: Element): void { reset(resolveTarget(el)); }
+  // Interrupted mid-flight (e.g. rapid open→close, single-open switch A→B): stop
+  // the running animation (so its safety timer cannot fire later) and drop our
+  // inline styles.
+  function onEnterCancelled(el: Element): void {
+    const t = resolveTarget(el);
+    active.get(t)?.();
+    reset(t);
+  }
+  function onLeaveCancelled(el: Element): void {
+    const t = resolveTarget(el);
+    active.get(t)?.();
+    reset(t);
+  }
 
   return { onEnter, onLeave, onEnterCancelled, onLeaveCancelled };
 }

--- a/test/unit/composables/useInlineExpand.test.ts
+++ b/test/unit/composables/useInlineExpand.test.ts
@@ -75,4 +75,25 @@ describe('useInlineExpand', () => {
     vi.advanceTimersByTime(INLINE_EXPAND_MS + 80);
     expect(done).toHaveBeenCalledTimes(1);
   });
+
+  it('stops the in-flight enter and clears styles when cancelled (no late resolve)', () => {
+    vi.useFakeTimers();
+    mockReducedMotion(false);
+    const { onEnter, onEnterCancelled } = useInlineExpand();
+    const el = document.createElement('div');
+    const done = vi.fn();
+
+    onEnter(el, done);
+    expect(el.style.overflow).toBe('hidden'); // animation armed
+
+    onEnterCancelled(el);
+
+    // Inline styles are dropped immediately…
+    expect(el.style.height).toBe('');
+    expect(el.style.transition).toBe('');
+    // …and the cancelled enter's safety timer must NOT resolve afterwards
+    // (a stale timer would otherwise clobber a subsequent leave animation).
+    vi.advanceTimersByTime(INLINE_EXPAND_MS + 80);
+    expect(done).not.toHaveBeenCalled();
+  });
 });

--- a/test/unit/composables/useInlineExpand.test.ts
+++ b/test/unit/composables/useInlineExpand.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { useInlineExpand, INLINE_EXPAND_MS } from '../../../src/composables/useInlineExpand';
+
+/**
+ * The animation itself (real height interpolation) needs a layout engine and is
+ * verified live. These tests pin the deterministic, accessibility-relevant
+ * behaviour: reduced-motion short-circuit, guaranteed completion via the safety
+ * timer (jsdom never fires `transitionend`), and inner-target resolution.
+ */
+function mockReducedMotion(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockReturnValue({ matches }),
+  });
+}
+
+describe('useInlineExpand', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('skips the animation and resolves immediately under prefers-reduced-motion', () => {
+    mockReducedMotion(true);
+    const { onEnter } = useInlineExpand();
+    const el = document.createElement('div');
+    const done = vi.fn();
+
+    onEnter(el, done);
+
+    expect(done).toHaveBeenCalledTimes(1);
+    // No inline animation styles were applied.
+    expect(el.style.height).toBe('');
+    expect(el.style.transition).toBe('');
+  });
+
+  it('arms the transition and resolves via the safety timer when no transitionend fires', () => {
+    vi.useFakeTimers();
+    mockReducedMotion(false);
+    const { onEnter } = useInlineExpand();
+    const el = document.createElement('div');
+    const done = vi.fn();
+
+    onEnter(el, done);
+
+    // Enter started: clipped + transition armed, not yet resolved.
+    expect(el.style.overflow).toBe('hidden');
+    expect(el.style.transition).toContain(`${INLINE_EXPAND_MS}ms`);
+    expect(done).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(INLINE_EXPAND_MS + 80);
+
+    expect(done).toHaveBeenCalledTimes(1);
+    // Inline styles cleared back to the natural state.
+    expect(el.style.height).toBe('');
+    expect(el.style.overflow).toBe('');
+  });
+
+  it('animates an inner element when a selector is given (list <tr> case)', () => {
+    vi.useFakeTimers();
+    mockReducedMotion(false);
+    const { onEnter } = useInlineExpand('.lb-inline-anim');
+    const row = document.createElement('tr');
+    const inner = document.createElement('div');
+    inner.className = 'lb-inline-anim';
+    row.appendChild(inner);
+    const done = vi.fn();
+
+    onEnter(row, done);
+
+    // The inner wrapper is animated, the <tr> itself is left untouched.
+    expect(inner.style.overflow).toBe('hidden');
+    expect(row.style.overflow).toBe('');
+
+    vi.advanceTimersByTime(INLINE_EXPAND_MS + 80);
+    expect(done).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- The inline editor now slides open/closed (height accordion + opacity fade) instead of popping via a bare `v-if` — animates on BOTH open and close.
- Shared composable `useInlineExpand` (Vue `<transition>` JS hooks, `:css="false"`) used by GridView and ListView (DRY).
- The list editor lives in a `<tr>`, which can't be CSS height-animated, so an inner `.lb-inline-anim` wrapper is animated and the row follows.
- Respects `prefers-reduced-motion` (instant, no animation); a safety timer guarantees completion if no `transitionend` fires, so the editor never gets stuck.
- Single tunable source of truth: `INLINE_EXPAND_MS` / `INLINE_EXPAND_EASING` at the top of the composable.

## Test plan
- [x] `npm run type-check` — passes
- [x] `npm run lint` — 0 errors (188 warnings = unchanged baseline)
- [x] `npm run test` — 64 passing (3 new for `useInlineExpand`: reduced-motion short-circuit, safety-timer completion, inner-target resolution)
- [x] `npm run build` — succeeds
- [ ] Visual smoke in local Directus (sandbox Chrome can't render — verified by reviewer): grid + list expand/collapse, single-open switch (A closes while B opens), and `prefers-reduced-motion`

Part of #77